### PR TITLE
Fix branch docker tag to push to Nexus staging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
                                     docker.withRegistry("https://${env.DOCKER_REGISTRY}:10004") {
                                         image_amd64.push(env.VERSION)
                                         image_amd64.push('latest')
-                                        image_amd64.push("${env.GIT_BRANCH}")
+                                        image_amd64.push("${env.SEMVER_BRANCH}")
                                         image_amd64.push("${env.GIT_COMMIT}-${env.VERSION}")
                                     }
                                 }
@@ -163,7 +163,7 @@ pipeline {
                                     docker.withRegistry("https://${env.DOCKER_REGISTRY}:10004") {
                                         image_arm64.push(env.VERSION)
                                         image_arm64.push('latest')
-                                        image_arm64.push("${env.GIT_BRANCH}")
+                                        image_arm64.push("${env.SEMVER_BRANCH}")
                                         image_arm64.push("${env.GIT_COMMIT}-${env.VERSION}")
                                     }
                                 }


### PR DESCRIPTION
Changes the branch name from "origin/master" to "master" to fix the issue of docker tags not allowing the "/" character

SEMVER_BRANCH variable is set in edgeXSetupEnvironment()
https://github.com/edgexfoundry/edgex-global-pipelines/blob/master/vars/edgeXSetupEnvironment.groovy#L31

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>