### PR TITLE
feat(profile): Add environment override for profile command line argument

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.12
 
-require (
-	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/edgexfoundry/app-functions-sdk-go v0.2.0-dev.30
-	gopkg.in/yaml.v2 v2.2.2 // indirect
-)
+require github.com/edgexfoundry/app-functions-sdk-go v0.2.0-dev.45


### PR DESCRIPTION
When running app-service-configurable or any service as a snap service changing the command line options is not possible. Thus the need to add an environment override for specifying the profile.

closes #22
