### PR TITLE
feat(PushToCore): Add PushToCore function to pipeline configurations

### DIFF
--- a/res/configuration.toml
+++ b/res/configuration.toml
@@ -1,5 +1,6 @@
 [Writable]
   LogLevel = "INFO"
+
   # The Pipeline section allows the functions pipeline to be specified via configuration
   [Writable.Pipeline]
     # If True, the incoming data to the functions pipeline will be []byte, i.e not marshaled to an Event
@@ -32,6 +33,10 @@
         InitVector = "123456789012345678901234567890"
     [Writable.Pipeline.Functions.SetOutputData]
     [Writable.Pipeline.Functions.MarkAsPushed]
+    [Writable.Pipeline.Functions.PushToCore]
+      [Writable.Pipeline.Functions.PushToCore.Parameters]
+        DeviceName = ""
+        ReadingName = ""
     [Writable.Pipeline.Functions.HTTPPost]
       [Writable.Pipeline.Functions.HTTPPost.Parameters]
         url = "http://"

--- a/res/docker-blackbox-tests/configuration.toml
+++ b/res/docker-blackbox-tests/configuration.toml
@@ -91,20 +91,7 @@ Type = "consul"
   Port = 48061
 
 [Binding]
-Type="messagebus"
-SubscribeTopic="events"
-PublishTopic="example"
-
-[MessageBus]
-Type = "zero"
-    [MessageBus.SubscribeHost]
-        Host = "edgex-core-data"
-        Port = 5563
-        Protocol = "tcp"
-    [MessageBus.PublishHost]
-        Host = "*"
-        Port = 5565
-        Protocol = "tcp"
+Type="http"
 
 [Logging]
 EnableRemote = true

--- a/res/docker-push-to-core/configuration.toml
+++ b/res/docker-push-to-core/configuration.toml
@@ -1,0 +1,55 @@
+[Writable]
+  LogLevel = "INFO"
+  # The Pipeline section allows the functions pipeline to be specified via configuration
+  [Writable.Pipeline]
+    # If True, the incoming data to the functions pipeline will be []byte, i.e not marshaled to an Event
+    # This is useful when the incoming data isn't an EdgeX Event.
+    UseTargetTypeOfByteArray = true
+
+    # ExecutionOrder specifies which functions to run and the order to run them.
+    # All functions listed must have an entry below in the Pipeline.Functions section
+    ExecutionOrder = "PushToCore"
+
+    # The Pipeline.Functions sections define the parameter configuration for each specific function.
+    # These function names must match a function define in the configurable package of the SDK.
+    # See the Built-In Transforms/Functions section of the SDK"s README for complete list.
+    # Some functions do not require any parameters, but still must be listed.
+    # Also, functions not specified in ExecutionOrder above can still be included which allows for easier
+    # dynamic changes from Consul.
+    [Writable.Pipeline.Functions.PushToCore]
+      [Writable.Pipeline.Functions.PushToCore.Parameters]
+        DeviceName = ""
+        ReadingName = ""
+
+[Service]
+BootTimeout = 30000
+ClientMonitor = 15000
+CheckInterval = "10s"
+Host = "edgex-app-service-configurable-push-to-core"
+Port = 48095
+Protocol = "http"
+ReadMaxLimit = 100
+StartupMsg = "Configurable Application Service Started"
+Timeout = 5000
+
+[Registry]
+Host = "edgex-core-consul"
+Port = 8500
+Type = "consul"
+
+[Logging]
+EnableRemote = true
+
+[Clients]
+  [Clients.CoreData]
+  Protocol = "http"
+  Host = "edgex-core-data"
+  Port = 48080
+
+  [Clients.Logging]
+  Protocol = "http"
+  Host = "edgex-support-logging"
+  Port = 48061
+
+[Binding]
+Type="http"

--- a/res/push-to-core/configuration.toml
+++ b/res/push-to-core/configuration.toml
@@ -1,0 +1,56 @@
+[Writable]
+  LogLevel = "INFO"
+  # The Pipeline section allows the functions pipeline to be specified via configuration
+  [Writable.Pipeline]
+    # If True, the incoming data to the functions pipeline will be []byte, i.e not marshaled to an Event
+    # This is useful when the incoming data isn't an EdgeX Event.
+    UseTargetTypeOfByteArray = true
+
+    # ExecutionOrder specifies which functions to run and the order to run them.
+    # All functions listed must have an entry below in the Pipeline.Functions section
+    ExecutionOrder = "PushToCore"
+
+    # The Pipeline.Functions sections define the parameter configuration for each specific function.
+    # These function names must match a function define in the configurable package of the SDK.
+    # See the Built-In Transforms/Functions section of the SDK"s README for complete list.
+    # Some functions do not require any parameters, but still must be listed.
+    # Also, functions not specified in ExecutionOrder above can still be included which allows for easier
+    # dynamic changes from Consul.
+    [Writable.Pipeline.Functions.PushToCore]
+      [Writable.Pipeline.Functions.PushToCore.Parameters]
+        DeviceName = ""
+        ReadingName = ""
+
+[Service]
+BootTimeout = 30000
+ClientMonitor = 15000
+CheckInterval = "10s"
+Host = "localhost"
+Port = 48095
+Protocol = "http"
+ReadMaxLimit = 100
+StartupMsg = "Configurable Application Service Started"
+Timeout = 5000
+
+[Registry]
+Host = "localhost"
+Port = 8500
+Type = "consul"
+
+[Logging]
+EnableRemote = false
+File = "./logs/app-service-configurable.log"
+
+[Clients]
+  [Clients.CoreData]
+  Protocol = "http"
+  Host = "localhost"
+  Port = 48080
+
+  [Clients.Logging]
+  Protocol = "http"
+  Host = "localhost"
+  Port = 48061
+
+[Binding]
+Type="http"


### PR DESCRIPTION
Add PushToCore function to pipeline configuration in full sample configs.
Add new `push-to-core` profile that is tailored for HTTP trigger ingestion.

Completes https://github.com/edgexfoundry/app-functions-sdk-go/issues/200