### PR TITLE
Add snap packaging

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,73 @@
+# EdgeX Foundry App Service Configurable Snap
+[![snap store badge](https://raw.githubusercontent.com/snapcore/snap-store-badges/master/EN/%5BEN%5D-snap-store-black-uneditable.png)](https://snapcraft.io/edgex-app-service-configurable)
+
+This folder contains snap packaging for the EdgeX Foundry's App Service Configurable application service.
+
+The project maintains a rolling release of the snap on the `edge` channel that is rebuilt and published at least once daily through the jenkins jobs setup for the EdgeX project. You can see the jobs run [here](https://jenkins.edgexfoundry.org/view/Snap/) specifically looking at the `edgex-app-service-configurable-snap-{branch}-stage-snap`.
+
+The snap currently supports both `amd64` and `arm64` platforms.
+
+## Installation
+
+### Installing snapd
+The snap can be installed on any system that supports snaps. You can see how to install 
+snaps on your system [here](https://snapcraft.io/docs/installing-snapd/6735).
+
+However for full security confinement, the snap should be installed on an 
+Ubuntu 16.04 LTS or later Desktop or Server, or a system running Ubuntu Core 16 or later.
+
+### Installing EdgeX App Service Configurable as a snap
+The snap is published in the snap store at https://snapcraft.io/edgex-app-service-configurable.
+You can see the current revisions available for your machine's architecture by running the command:
+
+```bash
+$ snap info edgex-app-service-configurable
+```
+
+The snap can be installed using `snap install`. To install the snap from the edge channel:
+
+```bash
+$ sudo snap install edgex-app-service-configurable --edge
+```
+Lastly, on a system supporting it, the snap may be installed using GNOME (or Ubuntu) Software Center by searching for `edgex-app-service-configurable`.
+
+**Note** - the snap has only been tested on Ubuntu Desktop/Server versions 18.04 and 16.04, as well as Ubuntu Core versions 16 and 18.
+
+## Using the EdgeX App Service Configurable snap
+
+The App Service Configurable application service allows a variety of use cases to be met by simply providing configuration (vs. writing code). For more information about this service, please refer to the README. As with device-mqtt, this service is disabled when first installed, as it requires configuration changes before it can be run. As with the device-mqtt snap, the configuration.toml file is found in the snap’s writable area:
+
+
+/var/snap/edgex-app-service-configurable/current/config/res/
+
+### Profiles
+In additional to base configuration.toml in this directory, there are a number of sub-directories that also contain configuration.toml files. These sub-directories are referred to as profiles. The service’s default behavior is to use the configuration.toml file from the /res directory. If you want to use one of the profiles, use the snap set command to instruct the service to read its configuration from one of these sub-directories. For example, to use the push-to-core profile you would run:
+```
+$ sudo snap set edgex-app-service-configurable profile=push-to-core
+```
+In addition to instructing the service to read a different configuration file, the profile will also be used to name the service when it registers itself to the system.
+
+**Note** - as this service is based on the latest development release of EdgeX, not all use cases are supported, in particular integration with the EdgeX rules-engine will not work when used in conjunction with the Edinburgh release of EdgeX, but will work with the Fuji release. Perform the following steps to install the edgex-app-service-configurable application service using the mqtt-export-configuration example and Mosquitto to test:
+```
+sudo snap install edgex-app-service-configurable
+
+sudo snap set edgex-app-service-configurable profile=mqtt-export
+
+sudo snap start --enable edgex-app-service-configurable.app-service-configurable
+
+mosquitto_sub -t "edgex-events"
+```
+### Multiple Instances
+Multiple instances of edgex-app-service-configurable can be installed by using snap [Parallel Installs](https://snapcraft.io/docs/parallel-installs). This is an experimental snap feature and must be first be enabled by running this command:
+```
+sudo snap set system experimental.parallel-instances=true
+```
+Now you can install multiple instances of the edgex-app-service-configurable snap by specifying a unique instance name when you install the snap. The instance name is a unique suffix which is appended to the snap name following the “_” character used as a delimeter. This name only needs to be specified for the second and susbequent instances of the snap.
+```
+sudo snap install edgex-app-service-configurable edgex-app-service-configurable_http
+```
+or
+```
+sudo snap install edgex-app-service-configurable edgex-app-service-configurable_mqtt
+```
+**Note** – you must ensure that any configuration values that might cause conflict between the multiple instances (e.g. port, log file path, …) must be modified before enabling the snap’s service.

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+profile=$(snapctl get "profile")
+
+if [ -z "$profile" ]; then
+    echo "profile is empty!"
+    exit 0
+fi
+
+if [ "$profile" == "default" ]; then
+    exit 0;
+fi
+
+if [ ! -f "$SNAP_DATA/config/res/$profile/configuration.toml" ]; then
+    echo "invalid setting profile $profile specified; no configuration.toml found"
+    exit 1;
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+
+# get the values of $SNAP_DATA and $SNAP using the current symlink instead of
+# the default behavior which has the revision hard-coded, which breaks after
+# a refresh
+SNAP_DATA_CURRENT=${SNAP_DATA/%$SNAP_REVISION/current}
+SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
+
+# install all the config files from $SNAP/config/res/ into $SNAP_DATA/config,
+# but if files already exist, don't over-write
+mkdir -p "$SNAP_DATA/config"
+
+# create profile dirs if needed
+cd "$SNAP/config/"
+find . -maxdepth 2 -type d -exec mkdir -p "$SNAP_DATA/config/"{} \;
+
+# copy configuration files if needed and do replacement of the $SNAP,
+# $SNAP_DATA, $SNAP_COMMON environment variables in the config files
+find ./res -name "configuration.toml" | \
+    while read -r fname; do
+	if [ ! -f "$SNAP_DATA/config/$fname" ]; then
+	    cp "./$fname" "$SNAP_DATA/config/$fname"
+
+            sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
+                -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
+                -e "s@\$SNAP@$SNAP_CURRENT@g" \
+                "$SNAP_DATA/config/$fname"
+        fi
+    done
+
+# disable app-service-configurable initially because it specific requires configuration
+# with a device profile that will be specific to each installation
+snapctl stop --disable "$SNAP_INSTANCE_NAME.app-service-configurable"
+
+# set default profile
+snapctl set profile=default

--- a/snap/local/runtime-helpers/bin/service-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/service-wrapper.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+PROFILE_OPT=""
+
+profile=$(snapctl get "profile")
+
+if [ ! -z "$profile" ]; then
+    if [ "$profile" != "default" ]; then
+        PROFILE_OPT="-profile $profile"
+    fi
+fi
+
+$SNAP/bin/app-service-configurable -confdir $SNAP_DATA/config/res $PROFILE_OPT --registry
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,12 +47,12 @@ parts:
       # note - we specifically don't use arch
       case "$(dpkg --print-architecture)" in
         amd64)
-          FILE_NAME=go1.11.9.linux-amd64.tar.gz
-          FILE_HASH=e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608
+          FILE_NAME=go1.12.12.linux-amd64.tar.gz
+          FILE_HASH=4cf11ac6a8fa42d26ab85e27a5d916ee171900a87745d9f7d4a29a21587d78fc
           ;;
         arm64)
-          FILE_NAME=go1.11.9.linux-arm64.tar.gz
-          FILE_HASH=892ab6c2510c4caa5905b3b1b6a1d4c6f04e384841fec50881ca2be7e8accf05
+          FILE_NAME=go1.12.12.linux-arm64.tar.gz
+          FILE_HASH=a7e2fed536904f2bf7007deed3609b3484c55660821bd2faaeb6928fa62fd33e
           ;;
       esac
       # download the archive, failing on ssl cert problems

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,101 @@
+name: edgex-app-service-configurable
+base: core18
+adopt-info: app-service-config
+license: Apache-2.0
+summary:   The reference EdgeX App Service Configurable
+title: EdgeX App Service Configurable
+description: |
+  The reference EdgeX app-service-configurable is built using the App
+  Functions SDK. This service is provided as an easy way to get started
+  with processing data flowing through EdgeX. This service leverages the
+  App Functions SDK and provides a way for developers to use configuration
+  instead of having to compile standalone services to utilize built in
+  functions in the SDK. For a full list of supported/built-in functions
+  view the README located in the App Functions SDK repository.
+
+  https://github.com/edgexfoundry/app-functions-sdk-go/README
+
+  Initially the daemon in the snap is disabled - this allows the configuration
+  to be modified and provided to app-service-config in
+  "$SNAP_DATA/config/app-service-configurable/res" before starting.
+
+# TODO: add armhf when the project supports this
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+grade: stable
+confinement: strict
+
+# edinburgh release is epoch 1
+epoch: 1
+
+apps:
+  app-service-configurable:
+    adapter: full
+    command: bin/service-wrapper.sh
+    daemon: simple
+    plugs: [network, network-bind]
+
+parts:
+  go:
+    plugin: nil
+    source: snap/local
+    build-packages: [curl]
+    override-build: |
+      # use dpkg architecture to figure out our target arch
+      # note - we specifically don't use arch
+      case "$(dpkg --print-architecture)" in
+        amd64)
+          FILE_NAME=go1.11.9.linux-amd64.tar.gz
+          FILE_HASH=e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608
+          ;;
+        arm64)
+          FILE_NAME=go1.11.9.linux-arm64.tar.gz
+          FILE_HASH=892ab6c2510c4caa5905b3b1b6a1d4c6f04e384841fec50881ca2be7e8accf05
+          ;;
+      esac
+      # download the archive, failing on ssl cert problems
+      curl https://dl.google.com/go/$FILE_NAME -O
+      echo "$FILE_HASH $FILE_NAME" > sha256
+      sha256sum -c sha256 | grep OK
+      tar -C $SNAPCRAFT_STAGE -xf go*.tar.gz --strip-components=1
+    prime:
+      - "-*"
+
+  app-service-config:
+    source: .
+    plugin: make
+    build-packages: [gcc, git, libzmq3-dev, pkg-config]
+    stage-packages: [libzmq5]
+    after: [go]
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "1.1.0-dev.11-$(date +%Y%m%d)+$(git rev-parse --short HEAD)"
+    override-build: |
+      cd $SNAPCRAFT_PART_SRC
+      make build
+
+      # install the service binary
+      install -DT "./app-service-configurable" \
+         "$SNAPCRAFT_PART_INSTALL/bin/app-service-configurable"
+
+      # create config dirs
+      find ./res -maxdepth 1 -type d -exec install -d "$SNAPCRAFT_PART_INSTALL/config/"{} \;
+
+      # replace relative log paths in configuration.toml files with fully qualified paths
+      # prefixed with $SNAP_COMMON
+      find ./res -name "configuration.toml" | \
+          while read fname; do
+               cat "$fname" | sed -e s:\./logs/:\\'$SNAP_COMMON/'\: > \
+              "$SNAPCRAFT_PART_INSTALL/config/$fname"
+          done
+
+      install -DT "./Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/app-service-configurable/Attribution.txt"
+      install -DT "./LICENSE" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/app-service-configurable/LICENSE"
+
+  config-common:
+    plugin: dump
+    source: snap/local/runtime-helpers


### PR DESCRIPTION
This PR adds snap packaging to app-service-configurable which when built with snapcraft produces a  binary snap named 'edgex-app-service-configurable'.

This snap originally created and published by me, but I've now requested that the name be transferred to EdgeX Foundry. It's been tested by multiple people, and in fact was used by some of the teams at the recent EdgeX Hackathon.

Test instructions can be found in the README.md that's included in this PR. 