### PR TITLE
doc(profile): Move default configuration to "sample" profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,14 @@ COPY --from=builder /app/res/ /res/
 COPY --from=builder /app/app-service-configurable /app-service-configurable
 EXPOSE 48095
 
-ENTRYPOINT ["/app-service-configurable","--registry","--profile=OVERWRITEME","--confdir=/res"]
+# Default configuation has been moved to the new "default" profile.
+# Must always specify the profile using
+# environment:
+#   - edgex_profile: <profile>
+# or use
+# command: "-profile=<profile>"
+# If not you will recive error:
+# SDK initialization failed: Could not load configuration file (./res/configuration.toml)...
+
+ENTRYPOINT ["/app-service-configurable","--registry","--confdir=/res"]
 

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -80,7 +80,7 @@ Host = "localhost"
 Port = 48095
 Protocol = "http"
 ReadMaxLimit = 100
-StartupMsg = "Configurable Application Service Started"
+StartupMsg = "Sample Configurable Application Service Started"
 Timeout = "5s"
 
 [Registry]


### PR DESCRIPTION
Move default configuration to `sample` profile so there isn't a default configuration forcing user to specify a profile.

Update the README to document the provided profiles.

closes #36
