### PR TITLE
Always provide mongo credentials

### DIFF
--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -47,8 +47,8 @@ Type = "mongodb"
 Host = "localhost"
 Port = 27017
 Timeout = "30s"
-Username = ""
-Password = ""
+Username = "appservice"
+Password = "password"
 
 # SecretStore is required when Store and Forward is enabled and running with security
 # so Databse credentails can be pulled from Vault.

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -58,8 +58,8 @@ Type = "mongodb"
 Host = "localhost"
 Port = 27017
 Timeout = "30s"
-Username = ""
-Password = ""
+Username = "appservice"
+Password = "password"
 
 # SecretStore is required when Store and Forward is enabled and running with security
 # so Databse credentails can be pulled from Vault.

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -94,8 +94,8 @@ Type = "mongodb"
 Host = "localhost"
 Port = 27017
 Timeout = "30s"
-Username = ""
-Password = ""
+Username = "appservice"
+Password = "password"
 
 # SecretStore is required when Store and Forward is enabled and running with security
 # so Databse credentails can be pulled from Vault.


### PR DESCRIPTION
Mongo authentication is enabled by default.
That is why all micro-services need  to authenticate when trying to connect mongo

Fix: https://github.com/edgexfoundry/app-service-configurable/issues/50

Signed-off-by: difince <dianaa@vmware.com>