### PR TITLE
feat(MessageBus): Update to lasted go-mod-messaging and create sample profile for MQTT Message Bus

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -119,3 +119,6 @@ https://github.com/golang/sync/blob/master/LICENSE
 
 golang.org/x/text (Unspecified) https://github.com/golang/text
 https://github.com/golang/text/blob/master/LICENSE
+
+github.com/diegoholiveira/jsonlogic (MIT) https://github.com/diegoholiveira/
+https://github.com/diegoholiveira/jsonlogic/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.13
 
-require github.com/edgexfoundry/app-functions-sdk-go v1.0.0
+require github.com/edgexfoundry/app-functions-sdk-go v1.0.1-dev.22

--- a/res/sample-mqtt-msg-bus/configuration.toml
+++ b/res/sample-mqtt-msg-bus/configuration.toml
@@ -80,7 +80,7 @@ Host = "localhost"
 Port = 48095
 Protocol = "http"
 ReadMaxLimit = 100
-StartupMsg = "Sample Configurable Application Service Started"
+StartupMsg = "Sample Configurable Application Service (using MQTT Message Bus) Started"
 Timeout = "5s"
 
 [Registry]
@@ -126,16 +126,33 @@ SubscribeTopic="events"
 PublishTopic="example"
 
 [MessageBus]
-Type = "zero"
+Type = "mqtt"
     [MessageBus.SubscribeHost]
         Host = "localhost"
-        Port = 5563
+        Port = 1883
         Protocol = "tcp"
     [MessageBus.PublishHost]
-        Host = "*"
-        Port = 5565
+        Host = "localhost"
+        Port = 1883
         Protocol = "tcp"
-
+    [MessageBus.Optional]
+        # MQTT Specific options
+        # Client Identifiers
+        Username =""
+        Password =""
+        ClientId ="AppServiceSample"
+        # Connection information
+        Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+        KeepAlive    =  "10" # Seconds (must be 2 or greater)
+        Retained     = "false"
+        AutoReconnect  = "true"
+        ConnectTimeout = "5" # Seconds
+        # TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified
+        SkipCertVerify = "false"
+        CertFile       = ""
+        KeyFile        = ""
+        KeyPEMBlock    = ""
+        CertPEMBlock   = ""
 [Logging]
 EnableRemote = false
 File = "./logs/app-service-configurable.log"


### PR DESCRIPTION

Updated to use latest go-mode-messaging and created the new sample-mqtt-msg-bus profile that configures the MessageBus to use MQTT broker.
