### PR TITLE
fix: SecretStore configuration is optional

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.13
 
-require github.com/edgexfoundry/app-functions-sdk-go v1.0.1-dev.22
+require github.com/edgexfoundry/app-functions-sdk-go v1.0.1-dev.25

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -55,17 +55,19 @@ Password = "password"
 # Note when running in docker from compose file set the following environment variables:
 #   - SecretStore_Host: edgex-vault
 #   - SecretStore_ServerName: edgex-vault
-#   - SecretStore_RootCaCertPath: /vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem
-#   - SecretStore_TokenFile: /vault/config/assets/resp-init.json
 [SecretStore]
   Host = 'localhost'
   Port = 8200
   Path = '/v1/secret/edgex/appservice/'
   Protocol = 'https'
+  RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+  ServerName = 'localhost'
+  TokenFile = '/vault/config/assets/resp-init.json'
+  AdditionalRetryAttempts = 10
+  RetryWaitPeriod = "1s"
 
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken = 'edgex'
 
 [Clients]
   [Clients.CoreData]

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -66,17 +66,19 @@ Password = "password"
 # Note when running in docker from compose file set the following environment variables:
 #   - SecretStore_Host: edgex-vault
 #   - SecretStore_ServerName: edgex-vault
-#   - SecretStore_RootCaCertPath: /vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem
-#   - SecretStore_TokenFile: /vault/config/assets/resp-init.json
 [SecretStore]
   Host = 'localhost'
   Port = 8200
   Path = '/v1/secret/edgex/appservice/'
   Protocol = 'https'
+  RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+  ServerName = 'localhost'
+  TokenFile = '/vault/config/assets/resp-init.json'
+  AdditionalRetryAttempts = 10
+  RetryWaitPeriod = "1s"
 
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken = 'edgex'
 
 [Clients]
   [Clients.CoreData]

--- a/res/sample-mqtt-msg-bus/configuration.toml
+++ b/res/sample-mqtt-msg-bus/configuration.toml
@@ -98,16 +98,23 @@ Username = "appservice"
 Password = "password"
 
 # SecretStore is required when Store and Forward is enabled and running with security
-# so database credentials can be pulled from Vault.
+# so Databse credentails can be pulled from Vault.
+# Note when running in docker from compose file set the following environment variables:
+#   - SecretStore_Host: edgex-vault
+#   - SecretStore_ServerName: edgex-vault
 [SecretStore]
   Host = 'localhost'
   Port = 8200
-  Path = '/v1/secret/edgex/application-service/'
+  Path = '/v1/secret/edgex/appservice/'
   Protocol = 'https'
+  RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+  ServerName = 'localhost'
+  TokenFile = '/vault/config/assets/resp-init.json'
+  AdditionalRetryAttempts = 10
+  RetryWaitPeriod = "1s"
 
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken = 'edgex'
 
 [Clients]
   [Clients.CoreData]

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -98,16 +98,23 @@ Username = "appservice"
 Password = "password"
 
 # SecretStore is required when Store and Forward is enabled and running with security
-# so database credentials can be pulled from Vault.
+# so Databse credentails can be pulled from Vault.
+# Note when running in docker from compose file set the following environment variables:
+#   - SecretStore_Host: edgex-vault
+#   - SecretStore_ServerName: edgex-vault
 [SecretStore]
   Host = 'localhost'
   Port = 8200
-  Path = '/v1/secret/edgex/application-service/'
+  Path = '/v1/secret/edgex/appservice/'
   Protocol = 'https'
+  RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+  ServerName = 'localhost'
+  TokenFile = '/vault/config/assets/resp-init.json'
+  AdditionalRetryAttempts = 10
+  RetryWaitPeriod = "1s"
 
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken = 'edgex'
 
 [Clients]
   [Clients.CoreData]


### PR DESCRIPTION
closes https://github.com/edgexfoundry/app-functions-sdk-go/issues/315

Updated to use latest SDK with fix to not initialize secret client if configuration not set.

Also, updated SecretStore config for recent additions.