### PR TITLE
feat: upgrade to app-functions-sdk-go v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.13
 
-require github.com/edgexfoundry/app-functions-sdk-go v1.1.1-dev.3
+require github.com/edgexfoundry/app-functions-sdk-go v1.2.0

--- a/main.go
+++ b/main.go
@@ -31,12 +31,7 @@ func main() {
 	fmt.Println("Starting Configurable Application Service...")
 	edgexSdk := &appsdk.AppFunctionsSDK{ServiceKey: serviceKey}
 	if err := edgexSdk.Initialize(); err != nil {
-		message := fmt.Sprintf("SDK initialization failed: %v\n", err)
-		if edgexSdk.LoggingClient != nil {
-			edgexSdk.LoggingClient.Error(message)
-		} else {
-			fmt.Println(message)
-		}
+		edgexSdk.LoggingClient.Error(fmt.Sprintf("SDK initialization failed: %v\n", err))
 		os.Exit(-1)
 	}
 


### PR DESCRIPTION
* Upgrades app-functions-sdk-go to use v1.2.0 tag in go.mod
* Cleaned up SDK initialization logging error code (logging client is always initialized before reaching this code)