### PR TITLE
fix: Update sample configuration of mqtt-export to use MQTTSecretSend #108

### DIFF
--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -7,7 +7,7 @@
     MaxRetryCount = 10
 
   [Writable.Pipeline]
-    ExecutionOrder = "TransformToJSON, MQTTSend, MarkAsPushed"
+    ExecutionOrder = "TransformToJSON, MQTTSecretSend, MarkAsPushed"
 
     [Writable.Pipeline.Functions.TransformToJSON]
     [Writable.Pipeline.Functions.MarkAsPushed]


### PR DESCRIPTION
MQTTSend has been deprecated and the documentation suggests to use MQTTSecretSend.
However, the sample configuration under res/mqtt-export still uses MQTTSend.
This commit updates the sample configuration to use MQTTSecretSend.

Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adjust the sample configuration


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:
#108 

## What is the new behavior?
Sample configuration under res/mqtt-export specifies MQTTSecretSend in the ExecutionOrder

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
https://docs.edgexfoundry.org/1.2/microservices/application/AppServiceConfigurable/#mqttsend
## Other information