### PR TITLE
fix: SecretStoreExclusive must have an initial sub-path in `Path` specified.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.15
 
-require github.com/edgexfoundry/app-functions-sdk-go v1.2.1-dev.23
+require github.com/edgexfoundry/app-functions-sdk-go v1.2.1-dev.31

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -90,16 +90,17 @@ Timeout = "30s"
 # retieving the secrets from Vault for authenticated HTTP exports.
 # See HTTPSend documentation for more details on setting parameters for using secrets.
 #
-# Note that you must use the new /api/v1/secrets REST API on the App Service after a fresh & clean start
-# of the EdgeX services to POST your custom secrets so they are pushed into Vault.
-#
-# Note when running in docker from compose file set the following environment variables:
-#   - SecretStore_Host: edgex-vault
-#   - SecretStore_ServerName: edgex-vault
+# Note: That you must use the new /api/v1/secrets REST API on the App Service after a fresh & clean start
+#       of the EdgeX services to POST your custom secrets so they are pushed into Vault.
+# Note: The Path Path must have a sub-path after the service name.
+#       Here we have arbitrarily chosen `app` for the sub path.
+# Note: When running in docker from compose file set the following environment variables:
+#        - SecretStore_Host: edgex-vault
+#        - SecretStore_ServerName: edgex-vault
 [SecretStoreExclusive]
   Host = 'localhost'
   Port = 8200
-  Path = '/v1/secret/edgex/appservice-http-export/'
+  Path = '/v1/secret/edgex/appservice-http-export/app/'
   Protocol = 'https'
   RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
   ServerName = 'localhost'

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -116,16 +116,17 @@ Timeout = "30s"
 # retieving the secrets from Vault for authenticated MQTT exports.
 # See MQTTSecretSend documentation for more details on setting parameters for using secrets.
 #
-# Note that you must use the new /api/v1/secrets REST API on the App Service after a fresh & clean start
-# of the EdgeX services to POST your custom secrets so they are pushed into Vault.
-#
-# Note when running in docker from compose file set the following environment variables:
-#   - SecretStore_Host: edgex-vault
-#   - SecretStore_ServerName: edgex-vault
+# Note: That you must use the new /api/v1/secrets REST API on the App Service after a fresh & clean start
+#       of the EdgeX services to POST your custom secrets so they are pushed into Vault.
+# Note: The Path Path must have a sub-path after the service name.
+#       Here we have arbitrarily chosen `app` for the sub path.
+# Note: When running in docker from compose file set the following environment variables:
+#        - SecretStore_Host: edgex-vault
+#        - SecretStore_ServerName: edgex-vault
 [SecretStoreExclusive]
   Host = 'localhost'
   Port = 8200
-  Path = '/v1/secret/edgex/appservice-mqtt-export/'
+  Path = '/v1/secret/edgex/appservice-mqtt-export/app/'
   Protocol = 'https'
   RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
   ServerName = 'localhost'

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -177,16 +177,17 @@ Timeout = "30s"
 # retieving the secrets from Vault for authenticated HTTP or MQTT exports.
 # See HTTPSend and MQTTSecretSend documentation for more details on setting parameters for using secrets.
 #
-# Note that you must use the new /api/v1/secrets REST API on the App Service after a fresh & clean start
-# of the EdgeX services to POST your custom secrets so they are pushed into Vault.
-#
-# Note when running in docker from compose file set the following environment variables:
-#   - SecretStore_Host: edgex-vault
-#   - SecretStore_ServerName: edgex-vault
+# Note: That you must use the new /api/v1/secrets REST API on the App Service after a fresh & clean start
+#       of the EdgeX services to POST your custom secrets so they are pushed into Vault.
+# Note: The Path Path must have a sub-path after the service name.
+#       Here we have arbitrarily chosen `app` for the sub path.
+# Note: When running in docker from compose file set the following environment variables:
+#        - SecretStore_Host: edgex-vault
+#        - SecretStore_ServerName: edgex-vault
 [SecretStoreExclusive]
   Host = 'localhost'
   Port = 8200
-  Path = '/v1/secret/edgex/appservice-mqtt-export/'
+  Path = '/v1/secret/edgex/appservice-sample/app'
   Protocol = 'https'
   RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
   ServerName = 'localhost'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

User must specify `Path` when Storing Secrets, which is a bug. Should be able to leave `Path` empty

Issue Number: #119  


## What is the new behavior?

Storing Secrets empty `Path`  works

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information