### PR TITLE
fix: Enable using redis streams MessageBus in secure mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.15
 
-require github.com/edgexfoundry/app-functions-sdk-go v1.2.1-dev.35
+require github.com/edgexfoundry/app-functions-sdk-go v1.2.1-dev.39

--- a/res/rules-engine-redis/configuration.toml
+++ b/res/rules-engine-redis/configuration.toml
@@ -13,6 +13,15 @@
         ValueDescriptors = ""
         FilterOut = "false"
 
+    # InsecureSecrets are required for Store and Forward DB access and for authenticated HTTP exports when not using
+    # security services, i.e. Vault
+    [Writable.InsecureSecrets]
+      [Writable.InsecureSecrets.DB]
+        path = "redisdb"
+      [Writable.InsecureSecrets.DB.Secrets]
+        username = ""
+        Password = ""
+
 [Service]
 BootTimeout = "30s"
 CheckInterval = "10s"
@@ -39,6 +48,32 @@ Type = "consul"
   Protocol = "http"
   Host = "localhost"
   Port = 48061
+
+[Database]
+Type = "redisdb"
+Host = "localhost"
+Port = 6379
+Timeout = "30s"
+Password = ""
+
+# SecretStore is required when Store and Forward is enabled and running with security
+# so Databse credentails can be pulled from Vault.
+# Note when running in docker from compose file set the following environment variables:
+#   - SecretStore_Host: edgex-vault
+#   - SecretStore_ServerName: edgex-vault
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secret/edgex/appservice/'
+Protocol = 'https'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'localhost'
+TokenFile = '/vault/config/assets/resp-init.json'
+AdditionalRetryAttempts = 10
+RetryWaitPeriod = "1s"
+
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
 
 [Binding]
 Type="messagebus"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

rules-engine-redis profile only works in non-secure mode. Secure mode doesn't work because the random Redis password is required for the connected.

Issue Number: #126


## What is the new behavior?

rules-engine-redis profile works in secure and non-secure modes

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

no
## Are there any specific instructions or things that should be known prior to reviewing?

## Other information