### PR TITLE
feat(snap): added startup and duration interval values

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -40,6 +40,24 @@ The App Service Configurable application service allows a variety of use cases t
 
 /var/snap/edgex-app-service-configurable/current/config/res/
 
+### Startup environment variables
+
+EdgeX services by default wait 60s for dependencies (e.g. Core Data) to become available, and will exit after this time if the dependencies aren't met. The following options can be used to override this startup behavior on systems where it takes longer than expected for the dependent services provided by the edgexfoundry snap to start. Note, both options below are specified as a number of seconds.
+    
+To change the default startup duration (60 seconds), for a service to complete the startup, aka bootstrap, phase of execution by using the following command:
+
+```bash
+$ sudo snap set edgex-app-service-configurable startup-duration=60
+```
+
+The following environment variable overrides the retry startup interval or sleep time before a failure is retried during the start-up, aka bootstrap, phase of execution by using the following command:
+
+```bash
+$ sudo snap set edgex-app-service-configurable startup-interval=1
+```
+
+**Note** - Should the environment variables be modified after the service has started, the service must be restarted.
+
 ### Profiles
 In additional to base configuration.toml in this directory, there are a number of sub-directories that also contain configuration.toml files. These sub-directories are referred to as profiles. The service’s default behavior is to use the configuration.toml file from the /res directory. If you want to use one of the profiles, use the snap set command to instruct the service to read its configuration from one of these sub-directories. For example, to use the push-to-core profile you would run:
 ```

--- a/snap/local/runtime-helpers/bin/startup-env-var.sh
+++ b/snap/local/runtime-helpers/bin/startup-env-var.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+EDGEX_STARTUP_DURATION=$(snapctl get startup-duration)
+
+if [ -n "$EDGEX_STARTUP_DURATION" ]; then
+  export EDGEX_STARTUP_DURATION
+fi
+
+EDGEX_STARTUP_INTERVAL=$(snapctl get startup-interval)
+
+if [ -n "$EDGEX_STARTUP_INTERVAL" ]; then
+  export EDGEX_STARTUP_INTERVAL
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,6 +36,8 @@ apps:
   app-service-configurable:
     adapter: full
     command: bin/service-wrapper.sh
+    command-chain:
+      - bin/startup-env-var.sh
     daemon: simple
     plugs: [network, network-bind]
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

The module go-mod-bootstrap implements a service dependency check on startup which ensures that all of the runtime dependencies of a particular service are met before the service transitions to active state. With snap deployment, the default values should be sufficient for all of the services as the snap relies on systemd after/before statements to order the bringup of the services. 

To change the startup duration and/interval value of the service, you will need to modify the relevant configuration toml file.

Issue Number:


## What is the new behavior?
To change the default startup duration use:
sudo snap set edgex-app-service-configurable startup-duration=

To change the default startup interval use:
sudo snap set edgex-app-service-configurable startup-interval=

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?


## Other information
Should the environment variables be modified after the service has started, the service must be restarted.