### PR TITLE
refactor: Remove use of deprecated MQTTSend

### DIFF
--- a/res/blackbox-tests/configuration.toml
+++ b/res/blackbox-tests/configuration.toml
@@ -54,21 +54,19 @@
     [Writable.Pipeline.Functions.HTTPPostXML]
       [Writable.Pipeline.Functions.HTTPPostXML.Parameters]
         url = "http://"
-    [Writable.Pipeline.Functions.MQTTSend]
-      [Writable.Pipeline.Functions.MQTTSend.Parameters]
+    [Writable.Pipeline.Functions.MQTTSecretSend]
+      [Writable.Pipeline.Functions.MQTTSecretSend.Parameters]
+        brokeraddress = "tcps://localhost:8883"
+        topic = "mytopic"
+        secretpath = "mqtt"
+        clientid = "myclientid"
         qos="0"
-        key=""
         autoreconnect="false"
         retain="false"
-        cert=""
-      [Writable.Pipeline.Functions.MQTTSend.Addressable]
-        Address=   "localhost"
-        Port=      1883
-        Protocol=  "tcp"
-        Publisher= "MyApp"
-        User=      ""
-        Password=  ""
-        Topic=     "sampleTopic"
+        skipverify = "false"
+        authmode = "none"
+        persistOnError = "false"
+
 
 [Service]
 BootTimeout = "30s"

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -7,7 +7,7 @@
     MaxRetryCount = 10
 
   [Writable.Pipeline]
-    ExecutionOrder = "TransformToJSON, MQTTSend, MarkAsPushed"
+    ExecutionOrder = "TransformToJSON, MQTTSecretSend, MarkAsPushed"
 
     [Writable.Pipeline.Functions.TransformToJSON]
     [Writable.Pipeline.Functions.MarkAsPushed]
@@ -19,22 +19,6 @@
       [Writable.Pipeline.Functions.FilterByValueDescriptor.Parameters]
         ValueDescriptors = ""
         FilterOut = "false"
-    [Writable.Pipeline.Functions.MQTTSend]
-      [Writable.Pipeline.Functions.MQTTSend.Parameters]
-        qos="0"
-        key=""
-        autoreconnect="false"
-        retain="false"
-        cert=""
-        persistOnError = "false"
-      [Writable.Pipeline.Functions.MQTTSend.Addressable]
-        Address=   "localhost"
-        Port=      1883
-        Protocol=  "tcp"
-        Publisher= "AppServiceConfigurable-mqtt-export"
-        User=      ""
-        Password=  ""
-        Topic=     "edgex-events"
     [Writable.Pipeline.Functions.MQTTSecretSend]
       [Writable.Pipeline.Functions.MQTTSecretSend.Parameters]
         brokeraddress = "tcps://localhost:8883"

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -114,22 +114,6 @@
         skipverify = "false"
         authmode = "none"
         persistOnError = "false"
-    [Writable.Pipeline.Functions.MQTTSend]
-      [Writable.Pipeline.Functions.MQTTSend.Parameters]
-        qos="0"
-        key=""
-        autoreconnect="false"
-        retain="false"
-        cert=""
-        persistOnError = "false"
-      [Writable.Pipeline.Functions.MQTTSend.Addressable]
-        Address=   "localhost"
-        Port=      1883
-        Protocol=  "tcp"
-        Publisher= "MyApp"
-        User=      ""
-        Password=  ""
-        Topic=     "sampleTopic"
 
 # InsecureSecrets are required for Store and Forward DB access and for authenticated HTTP exports and MQTT exports with
 # new MQTTSecretSend function when not using security services, i.e. Vault


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Deprecated MQTTSend still in profiles and used for MQTT Export.

Issue Number: #108


## What is the new behavior?
Replace it with using MQTTSecretSend


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information