### PR TITLE
fix(snap): allow disabling of secret-store via config hook

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -89,3 +89,29 @@ or
 sudo snap install edgex-app-service-configurable edgex-app-service-configurable_mqtt
 ```
 **Note** – you must ensure that any configuration values that might cause conflict between the multiple instances (e.g. port, log file path, …) must be modified before enabling the snap’s service.
+
+### Secret Store Usage
+Some profile configuration.toml files specify configuration which requires secret-store support, however this snap doesn't fully support secure secrets without manual intervention (see below). The snap can also be configured to use insecure secrets as can be done via docker-compose by setting the option ```security-secret-store=false```. Ex.
+
+```
+sudo snap set edgex-app-service-configurable security-secret-store=false
+```
+
+### Manually configure the Secret Store (aka Vault) token
+Here's an example of how to use a configuration/profile which includes secrets:
+
+```
+$ sudo snap install edgex-app-service-configurable
+$ sudo snap set edgex-app-service-configurable profile=mqtt-export
+$ cd /var/snap/edgex-app-service-configurable/current/config/res/mqtt-export
+$ sudo cp /var/snap/edgexfoundry/current/secrets/edgex-application-service/secrets-token.json .
+```
+
+Next the profile's ```configuration.toml``` file (see ```/var/snap/edgex-app-service-configurable/current/config/res/mqtt-export```) needs to be updated to reference the new token file location in ```$SNAP_DATA```. The config field that need updated is ```SecretStore.TokenFile```. The following example shows how this can be done via the sed command-line tool, however the file can also be easily updated via your favorite editor.
+
+
+```
+$ sudo sed -i -e 's@/vault/config/assets/resp-init.json@/var/snap/edgex-app-service-configurable/current/config/res/mqtt-export/secrets-token.json@' ./configuration.toml
+```
+
+**Note** -- these configuration changes need to be made *before* the service is started for the first time. Otherwise, the recommended approach is to stop the service, delete the existing app-service-configurable configuration in Consul's kv store, and then proceed.

--- a/snap/README.md
+++ b/snap/README.md
@@ -14,7 +14,7 @@ The snap can be installed on any system that supports snaps. You can see how to 
 snaps on your system [here](https://snapcraft.io/docs/installing-snapd/6735).
 
 However for full security confinement, the snap should be installed on an 
-Ubuntu 16.04 LTS or later Desktop or Server, or a system running Ubuntu Core 16 or later.
+Ubuntu 18.04 LTS or later (Desktop or Server), or a system running Ubuntu Core 18 or later.
 
 ### Installing EdgeX App Service Configurable as a snap
 The snap is published in the snap store at https://snapcraft.io/edgex-app-service-configurable.
@@ -24,14 +24,19 @@ You can see the current revisions available for your machine's architecture by r
 $ snap info edgex-app-service-configurable
 ```
 
-The snap can be installed using `snap install`. To install the snap from the edge channel:
+The latest stable version of the snap can be installed using:
+
+```bash
+$ sudo snap install edgex-app-service-configurable
+```
+
+The latest development version of the snap can be installed using:
 
 ```bash
 $ sudo snap install edgex-app-service-configurable --edge
 ```
-Lastly, on a system supporting it, the snap may be installed using GNOME (or Ubuntu) Software Center by searching for `edgex-app-service-configurable`.
 
-**Note** - the snap has only been tested on Ubuntu Desktop/Server versions 18.04 and 16.04, as well as Ubuntu Core versions 16 and 18.
+**Note** - the snap has only been tested on Ubuntu Core, Desktop, and Server.
 
 ## Using the EdgeX App Service Configurable snap
 
@@ -65,16 +70,6 @@ $ sudo snap set edgex-app-service-configurable profile=push-to-core
 ```
 In addition to instructing the service to read a different configuration file, the profile will also be used to name the service when it registers itself to the system.
 
-**Note** - as this service is based on the latest development release of EdgeX, not all use cases are supported, in particular integration with the EdgeX rules-engine will not work when used in conjunction with the Edinburgh release of EdgeX, but will work with the Fuji release. Perform the following steps to install the edgex-app-service-configurable application service using the mqtt-export-configuration example and Mosquitto to test:
-```
-sudo snap install edgex-app-service-configurable
-
-sudo snap set edgex-app-service-configurable profile=mqtt-export
-
-sudo snap start --enable edgex-app-service-configurable.app-service-configurable
-
-mosquitto_sub -t "edgex-events"
-```
 ### Multiple Instances
 Multiple instances of edgex-app-service-configurable can be installed by using snap [Parallel Installs](https://snapcraft.io/docs/parallel-installs). This is an experimental snap feature and must be first be enabled by running this command:
 ```
@@ -91,7 +86,7 @@ sudo snap install edgex-app-service-configurable edgex-app-service-configurable_
 **Note** – you must ensure that any configuration values that might cause conflict between the multiple instances (e.g. port, log file path, …) must be modified before enabling the snap’s service.
 
 ### Secret Store Usage
-Some profile configuration.toml files specify configuration which requires secret-store support, however this snap doesn't fully support secure secrets without manual intervention (see below). The snap can also be configured to use insecure secrets as can be done via docker-compose by setting the option ```security-secret-store=false```. Ex.
+Some profile configuration.toml files specify configuration which requires Secret Store (aka Vault) support, however this snap doesn't yet fully support secure secrets without manual intervention (see below). The snap can also be configured to use insecure secrets as can be done via docker-compose by setting the option ```security-secret-store=false```. Ex.
 
 ```
 sudo snap set edgex-app-service-configurable security-secret-store=false

--- a/snap/local/runtime-helpers/bin/security-secret-store-env-var.sh
+++ b/snap/local/runtime-helpers/bin/security-secret-store-env-var.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+# check if security-secret-store is on/off
+# if it's not specified assume it's on
+
+SEC_STORE=$(snapctl get security-secret-store)
+if [ "$SEC_STORE" = "off" ]; then
+    # then export the env var as false to turn everything off
+    EDGEX_SECURITY_SECRET_STORE=false
+    export EDGEX_SECURITY_SECRET_STORE
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ apps:
     command: bin/service-wrapper.sh
     command-chain:
       - bin/startup-env-var.sh
+      - bin/security-secret-store-env-var.sh
     daemon: simple
     plugs: [network, network-bind]
 


### PR DESCRIPTION
This fix adds a new snap configure option 'security-secret-store'
that controls how secrets are stored. By default if a profile's
configuration file requires secrets, secret-store will be used.
If 'security-secret-store' is set to 'false', then insecure
secrets will be used instead. This aligns the snap with the same
capabilty available in the main edgexfoundry snap and the standard
docker-compose files.

Fixes: 150

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: 150

## What is the new behavior?
Secret store usage can now be disabled via a snap config option.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
NA

## Are there any specific instructions or things that should be known prior to reviewing?
See issue

## Test Instructions
Install the edgexfoundy snap from latest/stable:

`$ sudo snap install edgexfoundry
`

Build edgex-app-service-configurable from this branch:

```
$ sudo snap install snapcraft --classic
$ snapcraft --use-lxd
$ sudo snap install edgex-app-service-configurable*amd64.snap --dangerous
```

Set the profile to mqtt-export (which uses secrets by default):

`$ sudo snap set edgex-app-service-configurable profile=mqtt-export
`

In a separate terminal start journalctl to follow system log messages:

`$ sudo journalctl -f -o cat
`

Start edgex-app-service-configurable and see that it fails to start.

`$ sudo snap start --enable edgex-app-service-configurable.app-service-configurable 
`

Stop it, set security-secret-store=off, and start it. This time it should come up with no errors logged.

```
$ sudo snap stop edgex-app-service-configurable.app-service-configurable
$ sudo snap set edgex-app-service-configurable security-secret-store=off
$ sudo snap start --enable edgex-app-service-configurable.app-service-configurable 
```

Verify that it up using snap services:

```
$ snap services edgex-app-service-configurable.app-service-configurable 
Service                                                  Startup   Current  Notes
edgex-app-service-configurable.app-service-configurable  enabled  active   -
```
