### PR TITLE
fix: All pipeline functions require 1 or more parameters in configuration

### DIFF
--- a/res/blackbox-tests/configuration.toml
+++ b/res/blackbox-tests/configuration.toml
@@ -29,9 +29,20 @@
       [Writable.Pipeline.Functions.AddTags.Parameters]
         tags=""
     [Writable.Pipeline.Functions.TransformToXML]
+      [Writable.Pipeline.Functions.TransformToXML.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.TransformToJSON]
+      [Writable.Pipeline.Functions.TransformToJSON.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.CompressWithGZIP]
+      [Writable.Pipeline.Functions.CompressWithGZIP.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.CompressWithZLIB]
+      [Writable.Pipeline.Functions.CompressWithZLIB.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
+    [Writable.Pipeline.Functions.MarkAsPushed]
+      [Writable.Pipeline.Functions.MarkAsPushed.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.EncryptWithAES]
       [Writable.Pipeline.Functions.EncryptWithAES.Parameters]
         Key = "aquqweoruqwpeoruqwpoeruqwpoierupqoweiurpoqwiuerpqowieurqpowieurpoqiweuroipwqure"
@@ -39,7 +50,6 @@
     [Writable.Pipeline.Functions.SetOutputData]
       [Writable.Pipeline.Functions.SetOutputData.Parameters]
         ResponseContentType = ""
-    [Writable.Pipeline.Functions.MarkAsPushed]
     [Writable.Pipeline.Functions.PushToCore]
       [Writable.Pipeline.Functions.PushToCore.Parameters]
         DeviceName = ""

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -10,8 +10,21 @@
     UseTargetTypeOfByteArray = false
     ExecutionOrder = "FilterByDeviceName, TransformToJSON, HTTPPostJSON, MarkAsPushed"
 
+    [Writable.Pipeline.Functions.TransformToXML]
+      [Writable.Pipeline.Functions.TransformToXML.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.TransformToJSON]
+      [Writable.Pipeline.Functions.TransformToJSON.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
+    [Writable.Pipeline.Functions.CompressWithGZIP]
+      [Writable.Pipeline.Functions.CompressWithGZIP.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
+    [Writable.Pipeline.Functions.CompressWithZLIB]
+      [Writable.Pipeline.Functions.CompressWithZLIB.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.MarkAsPushed]
+      [Writable.Pipeline.Functions.MarkAsPushed.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.FilterByDeviceName]
       [Writable.Pipeline.Functions.FilterByDeviceName.Parameters]
         DeviceNames = ""
@@ -28,6 +41,12 @@
         secretpath = ""
     [Writable.Pipeline.Functions.HTTPPutJSON]
       [Writable.Pipeline.Functions.HTTPPutJSON.Parameters]
+        url = "http://"
+        persistOnError = "false"
+        secretheadername = "" # This is the name used in the HTTP header and also used as the secret key
+        secretpath = ""
+    [Writable.Pipeline.Functions.HTTPPostXML]
+      [Writable.Pipeline.Functions.HTTPPostXML.Parameters]
         url = "http://"
         persistOnError = "false"
         secretheadername = "" # This is the name used in the HTTP header and also used as the secret key

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -9,8 +9,21 @@
   [Writable.Pipeline]
     ExecutionOrder = "TransformToJSON, MQTTSecretSend, MarkAsPushed"
 
+    [Writable.Pipeline.Functions.TransformToXML]
+      [Writable.Pipeline.Functions.TransformToXML.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.TransformToJSON]
+      [Writable.Pipeline.Functions.TransformToJSON.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
+    [Writable.Pipeline.Functions.CompressWithGZIP]
+      [Writable.Pipeline.Functions.CompressWithGZIP.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
+    [Writable.Pipeline.Functions.CompressWithZLIB]
+      [Writable.Pipeline.Functions.CompressWithZLIB.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.MarkAsPushed]
+      [Writable.Pipeline.Functions.MarkAsPushed.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.FilterByDeviceName]
       [Writable.Pipeline.Functions.FilterByDeviceName.Parameters]
         DeviceNames = ""

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -37,9 +37,20 @@
       [Writable.Pipeline.Functions.JSONLogic.Parameters]
         rule = "{ \"and\" : [{\"<\" : [{ \"var\" : \"temp\" }, 110 ]}, {\"==\" : [{ \"var\" : \"sensor.type\" }, \"temperature\" ]} ] }"
     [Writable.Pipeline.Functions.TransformToXML]
+      [Writable.Pipeline.Functions.TransformToXML.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.TransformToJSON]
+      [Writable.Pipeline.Functions.TransformToJSON.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.CompressWithGZIP]
+      [Writable.Pipeline.Functions.CompressWithGZIP.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.CompressWithZLIB]
+      [Writable.Pipeline.Functions.CompressWithZLIB.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
+    [Writable.Pipeline.Functions.MarkAsPushed]
+      [Writable.Pipeline.Functions.MarkAsPushed.Parameters]
+        NoOp = "" # Must have at least one parameter for function to be populated in Consul
     [Writable.Pipeline.Functions.EncryptWithAES]
       [Writable.Pipeline.Functions.EncryptWithAES.Parameters]
         Key = "aquqweoruqwpeoruqwpoeruqwpoierupqoweiurpoqwiuerpqowieurqpowieurpoqiweuroipwqure"
@@ -59,7 +70,6 @@
     [Writable.Pipeline.Functions.SetOutputData]
       [Writable.Pipeline.Functions.SetOutputData.Parameters]
         ResponseContentType = ""
-    [Writable.Pipeline.Functions.MarkAsPushed]
     [Writable.Pipeline.Functions.PushToCore]
       [Writable.Pipeline.Functions.PushToCore.Parameters]
         DeviceName = ""


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Now that `Addressable` was removed only the `Parameters` map remains which will not populate in Consul unless there is at least one parameter in the configuration functions configuration. 

Issue Number: #161


## What is the new behavior?
Added the dummy `NoOp` parameter configuration for each pipeline function that has no parameters to resolve this issue.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information