### PR TITLE
feat: Update profiles for new subsribe topic for V2 DTOs

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -143,3 +143,6 @@ https://github.com/go-playground/validator/blob/master/LICENSE
 
 leodido/go-urn (MIT) https://github.com/leodido/go-urn
 https://github.com/leodido/go-urn
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.15
 
-require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.4
+require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.7

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -115,8 +115,8 @@ Timeout = "30s"
   Port = 48080
 
 [Binding]
-Type="messagebus"
-SubscribeTopics="events"
+Type="edgex-messagebus"
+SubscribeTopics="events, edgex/events"
 
 [MessageBus]
 Type = "zero"

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -113,8 +113,8 @@ Timeout = "30s"
   Port = 48080
 
 [Binding]
-Type="messagebus"
-SubscribeTopics="events"
+Type="edgex-messagebus"
+SubscribeTopics="events, edgex/events"
 
 [MessageBus]
 Type = "zero"

--- a/res/rules-engine-mqtt/configuration.toml
+++ b/res/rules-engine-mqtt/configuration.toml
@@ -38,8 +38,8 @@ Type = "consul"
   Port = 48080
 
 [Binding]
-Type="messagebus"
-SubscribeTopics="events"
+Type="edgex-messagebus"
+SubscribeTopics="events, edgex/events/#"
 PublishTopic="rules-events"
 
 [MessageBus]

--- a/res/rules-engine-redis/configuration.toml
+++ b/res/rules-engine-redis/configuration.toml
@@ -73,8 +73,8 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Binding]
-Type="messagebus"
-SubscribeTopics="events"
+Type="edgex-messagebus"
+SubscribeTopics="events, edgex/events"
 PublishTopic="rules-events"
 
 [MessageBus]

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -38,8 +38,8 @@ Type = "consul"
   Port = 48080
 
 [Binding]
-Type="messagebus"
-SubscribeTopics="events"
+Type="edgex-messagebus"
+SubscribeTopics="events, edgex/events"
 PublishTopic="rules-events"
 
 [MessageBus]

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -195,8 +195,8 @@ Timeout = "30s"
   Port = 48080
 
 [Binding]
-Type="messagebus"
-SubscribeTopics="events"
+Type="edgex-messagebus"
+SubscribeTopics="events, edgex/events"
 PublishTopic="example"
 
 [MessageBus]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Using SDK that only supports V1 Event Model
All profiles that use MessageBus subscribe to `events` topic only.

Issue Number: #174


## What is the new behavior?
Updated to latest SDK that supports V2 Event DTO
All profiles using ZMQ for MessageBus have `edgex/events` added to existing `SubscribeTopics`.
All profiles using MQTT for MessageBus have `edgex/events/#` added to existing `SubscribeTopics`.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information