### PR TITLE
fix(snap): allow disabling of secret-store via config hook

### DIFF
--- a/snap/local/runtime-helpers/bin/security-secret-store-env-var.sh
+++ b/snap/local/runtime-helpers/bin/security-secret-store-env-var.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+# check if security-secret-store is on/off
+# if it's not specified assume it's on
+
+SEC_STORE=$(snapctl get security-secret-store)
+if [ "$SEC_STORE" = "off" ]; then
+    # then export the env var as false to turn everything off
+    EDGEX_SECURITY_SECRET_STORE=false
+    export EDGEX_SECURITY_SECRET_STORE
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ apps:
     command: bin/service-wrapper.sh
     command-chain:
       - bin/startup-env-var.sh
+      - bin/security-secret-store-env-var.sh
     daemon: simple
     plugs: [network, network-bind]
 


### PR DESCRIPTION
This fix adds a new snap configure option 'security-secret-store'
that controls how secrets are stored. By default if a profile's
configuration file requires secrets, secret-store will be used.
If 'security-secret-store' is set to 'false', then insecure
secrets will be used instead. This aligns the snap with the same
capabilty available in the main edgexfoundry snap and the standard
docker-compose files.

Fixes: 150

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: 150

## What is the new behavior?
Secret store usage can now be disabled via a snap config option.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
NA

## Are there any specific instructions or things that should be known prior to reviewing?
See issue

## Test Instructions
Install the edgexfoundy snap from latest/stable:

`$ sudo snap install edgexfoundry
`

Build edgex-app-service-configurable from this branch:

```
$ sudo snap install snapcraft --classic
$ snapcraft --use-lxd
$ sudo snap install edgex-app-service-configurable*amd64.snap --dangerous
```

Set the profile to mqtt-export (which uses secrets by default):

`$ sudo snap set edgex-app-service-configurable profile=mqtt-export
`

In a separate terminal start journalctl to follow system log messages:

`$ sudo journalctl -f -o cat
`

Start edgex-app-service-configurable and see that it fails to start.

`$ sudo snap start --enable edgex-app-service-configurable.app-service-configurable 
`

Stop it, set security-secret-store=off, and start it. This time it should come up with no errors logged.

```
$ sudo snap stop edgex-app-service-configurable.app-service-configurable
$ sudo snap set edgex-app-service-configurable security-secret-store=off
$ sudo snap start --enable edgex-app-service-configurable.app-service-configurable 
```

Verify that it up using snap services:

```
$ snap services edgex-app-service-configurable.app-service-configurable 
Service                                                  Startup   Current  Notes
edgex-app-service-configurable.app-service-configurable  enabled  active   -
```
