### PR TITLE
fix(snap): fix README's security-secret-store doc

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -86,10 +86,10 @@ sudo snap install edgex-app-service-configurable edgex-app-service-configurable_
 **Note** – you must ensure that any configuration values that might cause conflict between the multiple instances (e.g. port, log file path, …) must be modified before enabling the snap’s service.
 
 ### Secret Store Usage
-Some profile configuration.toml files specify configuration which requires Secret Store (aka Vault) support, however this snap doesn't yet fully support secure secrets without manual intervention (see below). The snap can also be configured to use insecure secrets as can be done via docker-compose by setting the option ```security-secret-store=false```. Ex.
+Some profile configuration.toml files specify configuration which requires Secret Store (aka Vault) support, however this snap doesn't yet fully support secure secrets without manual intervention (see below). The snap can also be configured to use insecure secrets as can be done via docker-compose by setting the option ```security-secret-store=off```. Ex.
 
 ```
-sudo snap set edgex-app-service-configurable security-secret-store=false
+sudo snap set edgex-app-service-configurable security-secret-store=off
 ```
 
 ### Manually configure the Secret Store (aka Vault) token


### PR DESCRIPTION
The snap's `README` incorrectly stated that security-secret-store could be set to `false` to disable secret store usage. The correct value is `off`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
NA

Issue Number: NA

## What is the new behavior?
NA

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information