### PR TITLE
refactor: Updated profiles to use service keys for Client names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.15
 
-require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.30
+require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.31

--- a/res/functional-tests/configuration.toml
+++ b/res/functional-tests/configuration.toml
@@ -78,7 +78,7 @@ Port = 8500
 Type = "consul"
 
 [Clients]
-  [Clients.CoreData]
+  [Clients.edgex-core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -113,7 +113,7 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Clients]
-  [Clients.CoreData]
+  [Clients.edgex-core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -119,7 +119,7 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Clients]
-  [Clients.CoreData]
+  [Clients.edgex-core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/push-to-core/configuration.toml
+++ b/res/push-to-core/configuration.toml
@@ -26,7 +26,7 @@ Port = 8500
 Type = "consul"
 
 [Clients]
-  [Clients.CoreData]
+  [Clients.edgex-core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/rules-engine-mqtt/configuration.toml
+++ b/res/rules-engine-mqtt/configuration.toml
@@ -40,7 +40,7 @@ Port = 8500
 Type = "consul"
 
 [Clients]
-  [Clients.CoreData]
+  [Clients.edgex-core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/rules-engine-redis/configuration.toml
+++ b/res/rules-engine-redis/configuration.toml
@@ -50,7 +50,7 @@ Port = 8500
 Type = "consul"
 
 [Clients]
-  [Clients.CoreData]
+  [Clients.edgex-core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -40,7 +40,7 @@ Port = 8500
 Type = "consul"
 
 [Clients]
-  [Clients.CoreData]
+  [Clients.edgex-core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -159,7 +159,7 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Clients]
-  [Clients.CoreData]
+  [Clients.edgex-core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080


### PR DESCRIPTION
Dependent on https://github.com/edgexfoundry/app-functions-sdk-go/pull/747 to be merged first.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Clients configuration in profiles use old names for services.

Issue Number: #212


## What is the new behavior?
Clients configuration in profiles now use the standard service keys for the names for the services.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Clients configuration has changed

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information