### PR TITLE
fix: Add missing Database config to message-bus-redis profile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.15
 
-require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.43
+require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.50

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -85,7 +85,7 @@ Host = "localhost"
 Port = 8500
 Type = "consul"
 
-# Database is require when Store and Forward is enabled
+# Database is require when Store and Forward is enabled or when using Redis for the Messagebus
 # Note when running in docker from compose file set the following environment variables:
 # - Database_Host: edgex-redis
 [Database]

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -91,7 +91,7 @@ Host = "localhost"
 Port = 8500
 Type = "consul"
 
-# Database is require when Store and Forward is enabled
+# Database is require when Store and Forward is enabled or when using Redis for the Messagebus
 # Note when running in docker from compose file set the following environment variables:
 # - Database_Host: edgex-redis
 [Database]

--- a/res/rules-engine-redis/configuration.toml
+++ b/res/rules-engine-redis/configuration.toml
@@ -49,6 +49,14 @@ Host = "localhost"
 Port = 8500
 Type = "consul"
 
+# Database is require when Redis is used for secure message bus
+# Type is used as the secret name when getting credentials from the Secret Store
+[Database]
+Type = "redisdb"
+Host = "localhost"
+Port = 6379
+Timeout = "30s"
+
 [Clients]
   [Clients.edgex-core-data]
   Protocol = "http"

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -133,7 +133,9 @@ Host = "localhost"
 Port = 8500
 Type = "consul"
 
-# Database is require when Store and Forward is enabled
+# Database is require when Store and Forward is enabled or when using Redis for the Messagebus
+# Note when running in docker from compose file set the following environment variables:
+# - Database_Host: edgex-redis
 [Database]
 Type = "redisdb"
 Host = "localhost"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
`rules-engine-redis`  profile is missing the Database config section which is needed when Redis is used as the secure message bus

Issue Number: #232 


## What is the new behavior?
`rules-engine-redis` profile is now has the Database config section 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information