### PR TITLE
refactor: Remove V1 subscribe topic from profiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.15
 
-require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.50
+require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.52

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -120,7 +120,7 @@ RetryWaitPeriod = "1s"
 
 [Trigger]
 Type="edgex-messagebus"
-SubscribeTopics="events, edgex/events"
+SubscribeTopics="edgex/events"
   [Trigger.EdgexMessageBus]
   Type = "zero"
     [Trigger.EdgexMessageBus.SubscribeHost]

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -126,7 +126,7 @@ RetryWaitPeriod = "1s"
 
 [Trigger]
 Type="edgex-messagebus"
-SubscribeTopics="events, edgex/events"
+SubscribeTopics="edgex/events"
   [Trigger.EdgexMessageBus]
   Type = "zero"
     [Trigger.EdgexMessageBus.SubscribeHost]

--- a/res/rules-engine-mqtt/configuration.toml
+++ b/res/rules-engine-mqtt/configuration.toml
@@ -47,7 +47,7 @@ Type = "consul"
 
 [Trigger]
 Type="edgex-messagebus"
-SubscribeTopics="events, edgex/events/#"
+SubscribeTopics="edgex/events/#"
 PublishTopic="rules-events"
   [Trigger.EdgexMessageBus]
   Type = "mqtt"

--- a/res/rules-engine-redis/configuration.toml
+++ b/res/rules-engine-redis/configuration.toml
@@ -83,7 +83,7 @@ RetryWaitPeriod = "1s"
 
 [Trigger]
 Type="edgex-messagebus"
-SubscribeTopics="events, edgex/events"
+SubscribeTopics="edgex/events/#"
 PublishTopic="rules-events"
   [Trigger.EdgexMessageBus]
   Type = "redisstreams"

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -47,7 +47,7 @@ Type = "consul"
 
 [Trigger]
 Type="edgex-messagebus"
-SubscribeTopics="events, edgex/events"
+SubscribeTopics="edgex/events"
 PublishTopic="rules-events"
 
 [Trigger.EdgexMessageBus]

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -168,7 +168,7 @@ RetryWaitPeriod = "1s"
 
 [Trigger]
 Type="edgex-messagebus"
-SubscribeTopics="events, edgex/events"
+SubscribeTopics="edgex/events"
 PublishTopic="example"
   [Trigger.EdgexMessageBus]
   Type = "zero"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
SubsribeTopics in many profiles has `events` which was for V1

Issue Number: #239


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?
SubsribeTopics in  profiles no longer contains `events` which was for V1


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information