### PR TITLE
ci: update local docker image names in Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -26,9 +26,9 @@ docker:
 	    --build-arg https_proxy \
 		-f Dockerfile \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/docker-app-service-configurable:$(GIT_SHA) \
-		-t edgexfoundry/docker-app-service-configurable:master-dev \
-		-t nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master-dev \
+		-t edgexfoundry/app-service-configurable:$(GIT_SHA) \
+		-t edgexfoundry/app-service-configurable:${VERSION}-dev \
+		-t nexus3.edgexfoundry.org:10004/app-service-configurable:${VERSION}-dev \
 		.
 
 test:


### PR DESCRIPTION
As part of the Ireland release it was decided to remove the docker- in the image prefix and -go in the image suffix.