### PR TITLE
fix: Fix version used in local dev docker image

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,8 +27,7 @@ docker:
 		-f Dockerfile \
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/app-service-configurable:$(GIT_SHA) \
-		-t edgexfoundry/app-service-configurable:${VERSION}-dev \
-		-t nexus3.edgexfoundry.org:10004/app-service-configurable:${VERSION}-dev \
+		-t edgexfoundry/app-service-configurable:${APPVERSION}-dev \
 		.
 
 test:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md --


## What is the current behavior?
make docker use VERSION which isn't set
Issue Number: #250


## What is the new behavior?
make docker now uses APPVERSION.
Also remove unneeded tag for Nexus

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information