### PR TITLE
refactor: Update for new service key names and overrides for hyphen to underscore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ WORKDIR /app
 
 COPY go.mod .
 RUN go mod download
+RUN go mod tidy
 
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.16
 
-require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.58
+require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.60

--- a/res/functional-tests/configuration.toml
+++ b/res/functional-tests/configuration.toml
@@ -78,7 +78,7 @@ Port = 8500
 Type = "consul"
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -113,7 +113,7 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -119,7 +119,7 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/push-to-core/configuration.toml
+++ b/res/push-to-core/configuration.toml
@@ -26,7 +26,7 @@ Port = 8500
 Type = "consul"
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -73,7 +73,7 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -161,7 +161,7 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
   Port = 48080


### PR DESCRIPTION
Dependent on edgexfoundry/go-mod-core-contracts#613
Dependent on edgexfoundry/go-mod-bootstrap#216
Dependent on edgexfoundry/app-functions-sdk-go/pull/838

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## What is the current behavior?
Service key constants have the edgex- prefix


Issue Number:  #252 & #235


## What is the new behavior?

Service key constants no longer have the edgex- prefix
Hyphen in Overrides are converted to underscore

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Service key names used in configuration have changed.

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information