### PR TITLE
refactor: Update to assign and use new Port Assignments

### DIFF
--- a/res/functional-tests/configuration.toml
+++ b/res/functional-tests/configuration.toml
@@ -66,7 +66,7 @@ BootTimeout = "30s"
 CheckInterval = "10s"
 Host = "localhost"
 ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
-Port = 48095
+Port = 59705
 Protocol = "http"
 ReadMaxLimit = 100
 StartupMsg = "Configurable Application Service Started"
@@ -81,7 +81,7 @@ Type = "consul"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 48080
+  Port = 58880
 
 # SecretStore is required when Store and Forward is enabled and running with security
 # so Database credentials can be pulled from Vault. Also now require when running with secure Consul

--- a/res/functional-tests/configuration.toml
+++ b/res/functional-tests/configuration.toml
@@ -81,7 +81,7 @@ Type = "consul"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 58880
+  Port = 59880
 
 # SecretStore is required when Store and Forward is enabled and running with security
 # so Database credentials can be pulled from Vault. Also now require when running with secure Consul

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -116,7 +116,7 @@ RetryWaitPeriod = "1s"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 58880
+  Port = 59880
 
 [Trigger]
 Type="edgex-messagebus"

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -74,7 +74,7 @@ BootTimeout = "30s"
 CheckInterval = "10s"
 Host = "localhost"
 ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
-Port = 50003
+Port = 59704
 Protocol = "http"
 ReadMaxLimit = 100
 StartupMsg = "AppServiceConfigurable-http-export has Started"
@@ -116,7 +116,7 @@ RetryWaitPeriod = "1s"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 48080
+  Port = 58880
 
 [Trigger]
 Type="edgex-messagebus"

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -122,7 +122,7 @@ RetryWaitPeriod = "1s"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 58880
+  Port = 59880
 
 [Trigger]
 Type="edgex-messagebus"

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -80,7 +80,7 @@ BootTimeout = "30s"
 CheckInterval = "10s"
 Host = "localhost"
 ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
-Port = 50002
+Port = 59703
 Protocol = "http"
 ReadMaxLimit = 100
 StartupMsg = "AppServiceConfigurable-mqtt-export has Started"
@@ -122,7 +122,7 @@ RetryWaitPeriod = "1s"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 48080
+  Port = 58880
 
 [Trigger]
 Type="edgex-messagebus"

--- a/res/push-to-core/configuration.toml
+++ b/res/push-to-core/configuration.toml
@@ -14,7 +14,7 @@ BootTimeout = "30s"
 CheckInterval = "10s"
 Host = "localhost"
 ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
-Port = 48095
+Port = 59702
 Protocol = "http"
 ReadMaxLimit = 100
 StartupMsg = "Configurable Application Service Started"
@@ -29,7 +29,7 @@ Type = "consul"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 48080
+  Port = 58880
 
 # SecretStore is required when Store and Forward is enabled and running with security
 # so Database credentials can be pulled from Vault. Also now require when running with secure Consul

--- a/res/push-to-core/configuration.toml
+++ b/res/push-to-core/configuration.toml
@@ -29,7 +29,7 @@ Type = "consul"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 58880
+  Port = 59880
 
 # SecretStore is required when Store and Forward is enabled and running with security
 # so Database credentials can be pulled from Vault. Also now require when running with secure Consul

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -35,7 +35,7 @@ BootTimeout = "30s"
 CheckInterval = "10s"
 Host = "localhost"
 ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
-Port = 50001
+Port = 59701
 Protocol = "http"
 ReadMaxLimit = 100
 StartupMsg = "App Service for rules engine has Started"
@@ -76,7 +76,7 @@ RetryWaitPeriod = "1s"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 48080
+  Port = 58880
 
 [Trigger]
 Type="edgex-messagebus"

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -76,7 +76,7 @@ RetryWaitPeriod = "1s"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 58880
+  Port = 59880
 
 [Trigger]
 Type="edgex-messagebus"

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -122,7 +122,7 @@ BootTimeout = "30s"
 CheckInterval = "10s"
 Host = "localhost"
 ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
-Port = 48095
+Port = 59700
 Protocol = "http"
 ReadMaxLimit = 100
 StartupMsg = "Sample Configurable Application Service Started"
@@ -164,7 +164,7 @@ RetryWaitPeriod = "1s"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 48080
+  Port = 58880
 
 [Trigger]
 Type="edgex-messagebus"

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -164,7 +164,7 @@ RetryWaitPeriod = "1s"
   [Clients.core-data]
   Protocol = "http"
   Host = "localhost"
-  Port = 58880
+  Port = 59880
 
 [Trigger]
 Type="edgex-messagebus"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->


## What is the current behavior?
Ports assigned for Core/Supporting services are 408xx range
App services never had a ranged assigned

Issue Number: #257

## What is the new behavior?
Ports assigned for Core/Supporting services are 588xx range
App services now assigned the 597xx range

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: App Service Configurable default port numbers have changed.

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information