### PR TITLE
fix: Remove retry related properties and update secret path of SecretStore config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.16
 
-require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.66
+require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.67

--- a/res/functional-tests/configuration.toml
+++ b/res/functional-tests/configuration.toml
@@ -92,13 +92,11 @@ Type = "consul"
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/app-functional-tests/'
+Path = 'app-functional-tests/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/app-functional-tests/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -101,13 +101,11 @@ Timeout = "30s"
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/app-http-export/'
+Path = 'app-http-export/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/app-http-export/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -109,13 +109,11 @@ Timeout = "30s"
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/app-mqtt-export/'
+Path = 'app-mqtt-export/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/app-mqtt-export/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/res/push-to-core/configuration.toml
+++ b/res/push-to-core/configuration.toml
@@ -38,13 +38,11 @@ Type = "consul"
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/app-push-to-core/'
+Path = 'app-push-to-core/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/app-push-to-core/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -61,13 +61,11 @@ Timeout = "30s"
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/app-rules-engine/'
+Path = 'app-rules-engine/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/app-rules-engine/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -151,13 +151,11 @@ Timeout = "30s"
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/app-sample/'
+Path = 'app-sample/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/app-sample/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 


### PR DESCRIPTION
SecretStore config no longer support Retry related properties and secret path now only needs service specific path, /v1/secret/edgex/ automatically prefix in front of it.

Fixes: #271

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Retry  related properties exists and secret path is full path.

Issue Number:  #271 


## What is the new behavior?
Retry related properties are removed and secret path is just service specific.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
In draft mode until we have tagged app-function-sdk version available for go.mod from CI pipeline.
