### PR TITLE
fix: Make default http export secret settings blank as default

### DIFF
--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -55,9 +55,9 @@
       PersistOnError = "false"
       ContinueOnSendError = "false" # For chained multi destination exports, if true continues after send eror so next export function executes.
       ReturnInputData = "false"  # For chained multi destination exports if true, passes the input data to next export function.
-      HeaderName = "header" # Name of the header key to add to the HTTP header
-      SecretName = "api-key" # Name of the secret for the header value in the SecretStore
-      SecretPath = "http" # Path to the secret for the header value in the SecretStore
+      HeaderName = "" # Name of the header key to add to the HTTP header
+      SecretName = "" # Name of the secret for the header value in the SecretStore
+      SecretPath = "" # Path to the secret for the header value in the SecretStore
     # Partial name matching allows multiple instances of same function (configured differently) to be in the function pipeline.
     # This supports chaining export functions to export to multiple destinations. Name must start with name that matches built in function.
     [Writable.Pipeline.Functions.HTTPExport2]
@@ -69,9 +69,9 @@
       PersistOnError = "false"
       ContinueOnSendError = "false" # For chained multi destination exports, if true continues after send eror so next export function executes.
       ReturnInputData = "false"  # For chained multi destination exports if true, passing the input data to next export function
-      HeaderName = "header" # Name of the header key to add to the HTTP header
-      SecretName = "api-key" # Name of the secret for the header value in the SecretStore
-      SecretPath = "http" # Path to the secret for the header value in the SecretStore
+      HeaderName = "" # Name of the header key to add to the HTTP header
+      SecretName = "" # Name of the secret for the header value in the SecretStore
+      SecretPath = "" # Path to the secret for the header value in the SecretStore
 # InsecureSecrets are required for Store and Forward DB access and for authenticated HTTP exports when not using
 # security services, i.e. Vault
   [Writable.InsecureSecrets]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Http Export has secrets setting populated causing TAF tests to fail

Issue Number: #279


## What is the new behavior?
Http Export has secrets setting back to un-set

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information