### PR TITLE
fix: Add/Fix optional MQTT MessageBus settings

### DIFF
--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -144,3 +144,14 @@ Type="edgex-messagebus"
     [Trigger.EdgexMessageBus.Optional]
     authmode = 'usernamepassword'  # required for redis messagebus (secure or insecure).
     secretname = 'redisdb'
+    # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
+    # Client Identifiers
+    ClientId ="app-http-export"
+    # Connection information
+    Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+    KeepAlive    =  "10" # Seconds (must be 2 or greater)
+    Retained     = "false"
+    AutoReconnect  = "true"
+    ConnectTimeout = "5" # Seconds
+    # TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified
+    SkipCertVerify = "false"

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -137,3 +137,14 @@ Type="edgex-messagebus"
     [Trigger.EdgexMessageBus.Optional]
     authmode = 'usernamepassword'  # required for redis messagebus (secure or insecure).
     secretname = 'redisdb'
+    # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
+    # Client Identifiers
+    ClientId ="app-mqtt-export"
+    # Connection information
+    Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+    KeepAlive    =  "10" # Seconds (must be 2 or greater)
+    Retained     = "false"
+    AutoReconnect  = "true"
+    ConnectTimeout = "5" # Seconds
+    # TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified
+    SkipCertVerify = "false"

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -96,7 +96,7 @@ Type="edgex-messagebus"
     secretname = 'redisdb'
     # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
     # Client Identifiers
-    ClientId ="core-data"
+    ClientId ="app-rules-engine"
     # Connection information
     Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
     KeepAlive    =  "10" # Seconds (must be 2 or greater)

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -225,3 +225,14 @@ Type="edgex-messagebus"
     [Trigger.EdgexMessageBus.Optional]
     authmode = 'usernamepassword'  # required for redis messagebus (secure or insecure).
     secretname = 'redisdb'
+    # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
+    # Client Identifiers
+    ClientId ="app-sample"
+    # Connection information
+    Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+    KeepAlive    =  "10" # Seconds (must be 2 or greater)
+    Retained     = "false"
+    AutoReconnect  = "true"
+    ConnectTimeout = "5" # Seconds
+    # TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified
+    SkipCertVerify = "false"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->


## What is the current behavior?
Some Profiles are missing the additional optional MQTT MessaegBus settings so env overrides do not work when enable MQTT from compose files.
One has incorrect value for Client ID

Issue Number:  #304


## What is the new behavior?
All profiles have additional optional MQTT MessaegBus settings allowing env overrides to work properly
Client ID is set properly in all profiles

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

no
## Are there any specific instructions or things that should be known prior to reviewing?

## Other information