### PR TITLE
docs: Add Doc PR section, removed obsolete types section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,27 +4,17 @@ Please check if your PR fulfills the following requirements:
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
+### Related Docs PR now required (if applicable)
+Related Docs PR:
+
+If n/a for Docs PR, state why it is not applicable:
+
 <!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->
-
-## PR Type
-What kind of change does this PR introduce?
-<!-- Please check the one that applies to this PR using "x". -->
-
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Code style update (formatting, local variables)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build related changes
-- [ ] CI related changes
-- [ ] Documentation content changes
-- [ ] Other... Please describe:
-
 
 ## What is the current behavior?
 <!-- Please describe the current behavior and link to a relevant issue. -->
 
 Issue Number:
-
 
 ## What is the new behavior?
 
@@ -36,7 +26,8 @@ Issue Number:
 - [ ] No
 
 ## Are there any new imports or modules? If so, what are they used for and why?
-
+- [ ] Yes
+- [ ] No
 
 ## Are there any specific instructions or things that should be known prior to reviewing?
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## What is the current behavior?
PR template does have section for related Docs PR and has obsolete type section

Issue Number: n/a

## What is the new behavior?
PR template now has section for related Docs PR and no longer has obsolete type section


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
n/a

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information