### PR TITLE
fix(snap): create VERSION file during snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,13 +61,17 @@ parts:
     build-snaps:
       - go/1.16/stable
     stage-packages: [libzmq5]
-    override-pull: |
-      snapcraftctl pull
-      cd $SNAPCRAFT_PROJECT_DIR
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      snapcraftctl set-version ${GIT_VERSION}
     override-build: |
       cd $SNAPCRAFT_PART_SRC
+
+      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      if [ -z "$GIT_VERSION" ]; then
+        GIT_VERSION="0.0.0"
+      fi
+      snapcraftctl set-version ${GIT_VERSION}
+      echo $GIT_VERSION > ./VERSION
+
+      make tidy
       make build
 
       # install the service binary


### PR DESCRIPTION
The makefile requires a VERSION file to be present when building the device service.
This commit creates the file using the current git tag.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

1. Build the snap and verify that you see a valid version in

```
CGO_ENABLED=1 go build -ldflags "-X github.com/edgexfoundry/app-functions-sdk-go/v2/internal.SDKVersion=v2.0.2-dev.13 -X github.com/edgexfoundry/app-functions-sdk-go/v2/internal.ApplicationVersion=2.0.2-dev.15" -o app-service-configurable

```

2. Test the REST endpoint

```
sudo snap install ./edgex-app-service-configurable_2.0.2-dev.15_amd64.snap --dangerous
sudo snap set edgex-app-service-configurable profile=mqtt-export
sudo snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token
sudo snap start edgex-app-service-configurable.app-service-configurable 
curl http://localhost:59881/api/v2/version
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->