### PR TITLE
feat: Add CORS capability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.16
 
-require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.2-dev.31
+require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.2-dev.32

--- a/go.sum
+++ b/go.sum
@@ -52,10 +52,10 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
-github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.2-dev.31 h1:DNlJ5nLPZbTjZl4NRKtMRbFiIQyiOKjA6Dfj3TBnDyM=
-github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.2-dev.31/go.mod h1:4vsFo+vydMpsTqPQ0Eo8kTtdYG4N4MkKNlllzcIHEM0=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.13 h1:LvbGywemQcG2xgZi6MaK63b5G+Vt1SF3tP7Lly6DdVs=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.13/go.mod h1:FUTBZgP4hMyJOetw3WkM6trUs2SG3AceO3NAZhZyG9M=
+github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.2-dev.32 h1:qli2Il/QC88sn5uaJJYu6zgS05OjBnbX9yRgAs4hYN8=
+github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.2-dev.32/go.mod h1:G5PrFxn/MPzNGgFsePCeWG5od6na2Lxay8PVZqi9QhQ=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.14 h1:vTV7AM2HnP5HiIPzED7Cd1PAXsKpWjj6m/nP39L4fM4=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.14/go.mod h1:84xs+nDgmAu8X2qTWsj9GTkgcIQDzS+O/O6RjvFE38M=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.0.1-dev.5 h1:icE1aVlX7I3SJ0qPqZJchCr2JLe2TMRZlUMIM2qoivo=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.0.1-dev.5/go.mod h1:MvHit0MxBXN4bC8LL0NZRsw72ByRE1XwtVLQP9C+2vg=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0/go.mod h1:pfXURRetgIto0GR0sCjDrfa71hqJ1wxmQWi/mOzWfWU=
@@ -150,7 +150,6 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/res/external-mqtt-trigger/configuration.toml
+++ b/res/external-mqtt-trigger/configuration.toml
@@ -53,6 +53,14 @@ StartupMsg = "app-external-mqtt-trigger has Started"
 MaxResultCount = 0 # Not curently used by App Services.
 MaxRequestSize = 0 # Not curently used by App Services.
 RequestTimeout = "5s"
+  [Service.CORSConfiguration]
+  EnableCORS = false
+  CORSAllowCredentials = false
+  CORSAllowedOrigin = "https://localhost"
+  CORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE"
+  CORSAllowedHeaders = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+  CORSExposeHeaders = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+  CORSMaxAge = 3600
 
 [Registry]
 Host = "localhost"

--- a/res/functional-tests/configuration.toml
+++ b/res/functional-tests/configuration.toml
@@ -74,6 +74,14 @@ StartupMsg = "app-functional-tests Service Started"
 MaxResultCount = 0 # Not curently used by App Services.
 MaxRequestSize = 0 # Not curently used by App Services.
 RequestTimeout = "5s"
+  [Service.CORSConfiguration]
+  EnableCORS = false
+  CORSAllowCredentials = false
+  CORSAllowedOrigin = "https://localhost"
+  CORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE"
+  CORSAllowedHeaders = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+  CORSExposeHeaders = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+  CORSMaxAge = 3600
 
 [Registry]
 Host = "localhost"

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -96,6 +96,14 @@ StartupMsg = "app-http-export has Started"
 MaxResultCount = 0 # Not curently used by App Services.
 MaxRequestSize = 0 # Not curently used by App Services.
 RequestTimeout = "5s"
+  [Service.CORSConfiguration]
+  EnableCORS = false
+  CORSAllowCredentials = false
+  CORSAllowedOrigin = "https://localhost"
+  CORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE"
+  CORSAllowedHeaders = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+  CORSExposeHeaders = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+  CORSMaxAge = 3600
 
 [Registry]
 Host = "localhost"

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -89,6 +89,14 @@ StartupMsg = "app-mqtt-export has Started"
 MaxResultCount = 0 # Not curently used by App Services.
 MaxRequestSize = 0 # Not curently used by App Services.
 RequestTimeout = "5s"
+  [Service.CORSConfiguration]
+  EnableCORS = false
+  CORSAllowCredentials = false
+  CORSAllowedOrigin = "https://localhost"
+  CORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE"
+  CORSAllowedHeaders = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+  CORSExposeHeaders = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+  CORSMaxAge = 3600
 
 [Registry]
 Host = "localhost"

--- a/res/push-to-core/configuration.toml
+++ b/res/push-to-core/configuration.toml
@@ -23,6 +23,14 @@ StartupMsg = "app-push-to-core has Started"
 MaxResultCount = 0 # Not curently used by App Services.
 MaxRequestSize = 0 # Not curently used by App Services.
 RequestTimeout = "5s"
+  [Service.CORSConfiguration]
+  EnableCORS = false
+  CORSAllowCredentials = false
+  CORSAllowedOrigin = "https://localhost"
+  CORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE"
+  CORSAllowedHeaders = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+  CORSExposeHeaders = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+  CORSMaxAge = 3600
 
 [Registry]
 Host = "localhost"

--- a/res/rules-engine/configuration.toml
+++ b/res/rules-engine/configuration.toml
@@ -41,6 +41,14 @@ StartupMsg = "app-rules-engine has Started"
 MaxResultCount = 0 # Not curently used by App Services.
 MaxRequestSize = 0 # Not curently used by App Services.
 RequestTimeout = "5s"
+  [Service.CORSConfiguration]
+  EnableCORS = false
+  CORSAllowCredentials = false
+  CORSAllowedOrigin = "https://localhost"
+  CORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE"
+  CORSAllowedHeaders = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+  CORSExposeHeaders = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+  CORSMaxAge = 3600
 
 [Registry]
 Host = "localhost"

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -166,6 +166,14 @@ StartupMsg = "app-sample has Started"
 MaxResultCount = 0 # Not curently used by App Services.
 MaxRequestSize = 0 # Not curently used by App Services.
 RequestTimeout = "5s"
+  [Service.CORSConfiguration]
+  EnableCORS = false
+  CORSAllowCredentials = false
+  CORSAllowedOrigin = "https://localhost"
+  CORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE"
+  CORSAllowedHeaders = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+  CORSExposeHeaders = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+  CORSMaxAge = 3600
 
 [Registry]
 Host = "localhost"


### PR DESCRIPTION
All profiles now have the default CORS configuration.

closes #341

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Not Applicable. Just profile updates**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  Will be handled by @cloudxxx8 via this issue Create document to instruct the CORS settings edgex-docs#608

## Testing Instructions
1. Clone the branch for this PR
2. Clone the branch for SDK PR (https://github.com/edgexfoundry/app-functions-sdk-go/pull/983)
3. Build ASC
4. Run ASC - `./app-service-configurable -p functional-tests -s`
5. Send GET request to `localhost:59705/api/v2/ping`
6. Verify CORS headers not in response
7. Stop ASC
8. Modify ./res/functional-tests/configuration.toml to enable CORS
```
  [Service.CORSConfiguration]
  EnableCORS = true
```
9. rerun ASC - `./app-service-configurable -p functional-tests -s`
10. Send GET request to `localhost:59705/api/v2/ping`
11. Verify CORS headers are now in the response

## New Dependency Instructions (If applicable)
**N/A**