### PR TITLE
feat(snap): add content interface mount point for app-functional-tests secrets token

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,7 +38,7 @@ slots:
     interface: content
     content: edgex-secretstore-token
     source:
-      write: [$SNAP_DATA/app-http-export, $SNAP_DATA/app-mqtt-export]
+      write: [$SNAP_DATA/app-http-export, $SNAP_DATA/app-mqtt-export, $SNAP_DATA/app-functional-tests]
 
 apps:
   app-service-configurable:


### PR DESCRIPTION
This commit adds "app-functional-tests" to the list of bind mount points set up by the
edgex-secretstore-token slot, so that the secret store token for that profile is available
when running TAF tests.


Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) n/a
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->


### Confirm that the service starts up with the functional-tests profile:
1. build edgex-app-service-configurable_2.0.2-dev.25_amd64.snap 

```
# build ASC
git clone https://github.com/siggiskulason/app-service-configurable.git
cd app-service-configurable
git checkout fix-snap-build
snapcraft --use-lxd
```

2. then install, configure and start:
 
```
sudo snap install edgexfoundry --edge
sudo snap install ./edgex-app-service-configurable_2.0.2-dev.25_amd64.snap --dangerous`
snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token
sudo snap set edgex-app-service-configurable profile=functional-tests
sudo snap start edgex-app-service-configurable

```

3. Confirm that there is a token at `ls /var/snap/edgex-app-service-configurable/current/app-functional-tests/`
4. Confirm in the journal that the app service started up (msg="app-functional-tests Service Started")


### Optionally test using TAF tests:
1. Run the TAF tests:

```
git clone https://github.com/edgexfoundry/edgex-taf.git
cd edgex-taf/TAF/utils/scripts/snap
sudo ./run-tests.sh -t app-service
```
Expected result: tests fail

2. Then run the tests using a snap built using this PR

```
 
# run TAF tests - using the correct path for the snap you just built, to run the tests using that snap
cd edgex-taf/TAF/utils/scripts/snap
sudo ./run-tests.sh -t app-service -a /home/your-path/edgex-app-service-configurable_2.0.2-dev.25_amd64.snap
```
Expected result: tests pass





## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->