### PR TITLE
build(snap): upgrade base to core20

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: edgex-app-service-configurable
-base: core18
+base: core20
 adopt-info: app-service-config
 license: Apache-2.0
 summary:   The reference EdgeX App Service Configurable
@@ -10,10 +10,7 @@ description: |
   with processing data flowing through EdgeX. This service leverages the
   App Functions SDK and provides a way for developers to use configuration
   instead of having to compile standalone services to utilize built in
-  functions in the SDK. For a full list of supported/built-in functions
-  view the documentation located here:
-
-  https://docs.edgexfoundry.org/1.2/microservices/application/ApplServices/
+  functions in the SDK.
 
   Initially the daemon in the snap is disabled - this allows the configuration
   to be modified and provided to app-service-config in
@@ -48,8 +45,7 @@ apps:
       - bin/startup-env-var.sh
       - bin/security-secret-store-env-var.sh
     daemon: simple
-    passthrough:
-      install-mode: disable
+    install-mode: disable
     plugs: [network, network-bind]
 
 parts:


### PR DESCRIPTION
This PR upgrades the snap base from core18 to core20.

Also, it removes passthrough since `install-mode` is now available as `apps.<app-name>.install-mode`; see https://snapcraft.io/docs/snapcraft-yaml-reference

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
$ snapcraft
...                                                                                  
Snapped edgex-app-service-configurable_2.0.2-dev.30_amd64.snap
$ sudo snap install ./edgex-app-service-configurable_2.0.2-dev.30_amd64.snap --dangerous
edgex-app-service-configurable 2.0.2-dev.30 installed
$ sudo snap services edgex-app-service-configurable
Service                                                  Startup   Current   Notes
edgex-app-service-configurable.app-service-configurable  disabled  inactive  -
$ sudo snap start edgex-app-service-configurable
Started.
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->