### PR TITLE
feat: Used Batch for metrics-influxdb profile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.17
 
-require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.2.0-dev.49
+require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.2.0-dev.51
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690 // indirect
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.3.5 // indirect
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.18 // indirect
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.19 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3 // indirect
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.26 // indirect
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,10 +32,10 @@ github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9 h1:NAHC
 github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9/go.mod h1:9STzWAIpeXT1gYFvw0JM+BkyMmPKYv/ztBNgXX4hAOw=
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
-github.com/edgexfoundry/app-functions-sdk-go/v2 v2.2.0-dev.49 h1:NTJ+2zV0jFCc7bk75Lyk+hoTUNaedG4J+z8gL3odLfo=
-github.com/edgexfoundry/app-functions-sdk-go/v2 v2.2.0-dev.49/go.mod h1:Mwd8zJyLU8NqPfCtby1A7UBcPLMd0QgS+vcO0B87mf0=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.18 h1:6QR9vgrk9cunfWPe2sYMrWBIgSgcCSagQ9IE3ZropLE=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.18/go.mod h1:6Q+rUmzAizdpU3sqnzMzSHmX7Z69qN69xxl0up/mQQA=
+github.com/edgexfoundry/app-functions-sdk-go/v2 v2.2.0-dev.51 h1:ldp9aEZTVLqGoAPKXWRg976pJLAp56qalSnceQmT2D8=
+github.com/edgexfoundry/app-functions-sdk-go/v2 v2.2.0-dev.51/go.mod h1:+9KwRcQFPGQui/E1QltQVQQ15uMu5onqoBhiJ1FU6Ss=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.19 h1:WdrAEuZIvgyHZhhHpLhlTaamcpj5Vi9W/ApJKGc+8ak=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.19/go.mod h1:6Q+rUmzAizdpU3sqnzMzSHmX7Z69qN69xxl0up/mQQA=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3 h1:dTTExUFHza9eJmTABr8G4KOE8JKBMzZCVC3wARiwIg4=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3/go.mod h1:YP17JhMnXTitowXE13QJwFaKo0oc03iyoKLjWAYl4FE=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.26 h1:YebVI3gAJwFTMXKzB2erUonBC8eNrr+qLUGdtXFMjKs=

--- a/res/http-export/configuration.toml
+++ b/res/http-export/configuration.toml
@@ -43,6 +43,7 @@
       Mode = "bytimecount" # can be "bycount", "bytime" or "bytimecount"
       BatchThreshold = "30"
       TimeInterval = "60s"
+      MergeOnSend = "false"
     [Writable.Pipeline.Functions.AddTags]
       [Writable.Pipeline.Functions.AddTags.Parameters]
       Tags=""

--- a/res/metrics-influxdb/configuration.toml
+++ b/res/metrics-influxdb/configuration.toml
@@ -8,7 +8,7 @@
 
   [Writable.Pipeline]
   UseTargetTypeOfMetric  = true
-  ExecutionOrder = "ToLineProtocol, HTTPExport"
+  ExecutionOrder = "ToLineProtocol, Batch, HTTPExport"
 
   [Writable.Pipeline.Functions]
     [Writable.Pipeline.Functions.ToLineProtocol]
@@ -20,11 +20,13 @@
       Mode = "bytimecount" # can be "bycount", "bytime" or "bytimecount"
       BatchThreshold = "100"
       TimeInterval = "60s"
+      MergeOnSend = "true"
     [Writable.Pipeline.Functions.HTTPExport]
       [Writable.Pipeline.Functions.HTTPExport.Parameters]
       Method = "post"
       MimeType = "raw"
-      Url = "http:/<your-influxdb-host>:8086/api/v2/write?org=<your-org>&bucket=<your-bucket>&precision=ns"
+      Url = "http://localhost:8086/api/v2/write?org=metrics&bucket=edgex&precision=ns"
+#      Url = "http:/<your-influxdb-host>:8086/api/v2/write?org=<your-org>&bucket=<your-bucket>&precision=ns"
       HeaderName = "authorization" # Name of the header key to add to the HTTP header
       SecretName = "token" # Name of the secret for the header value in the SecretStore
       SecretPath = "influxdb" # Path to the secret for the header value in the SecretStore
@@ -38,7 +40,8 @@
     [Writable.InsecureSecrets.influxdb]
     path = "influxdb"
       [Writable.InsecureSecrets.influxdb.Secrets]
-      token = "Token <place InfluxDB token here>"
+      token = "Token 29ER8iMgQ5DPD_icTnSwH_66aUhSvD0ZZTkvMM59kZdIJOTNoJqcP-RHFCppblG3wSOb7LOqjp1xubA80uaWhQ=="
+#      token = "Token <place InfluxDB token here>"
 
   [Writable.Telemetry]
   Interval = "0s" # Don't report any metrics as that would be cyclic with this profiles' processing.

--- a/res/mqtt-export/configuration.toml
+++ b/res/mqtt-export/configuration.toml
@@ -42,6 +42,7 @@ LogLevel = "INFO"
       Mode = "bytimecount" # can be "bycount", "bytime" or "bytimecount"
       BatchThreshold = "30"
       TimeInterval = "60s"
+      MergeOnSend = "false"
     [Writable.Pipeline.Functions.AddTags]
       [Writable.Pipeline.Functions.AddTags.Parameters]
       Tags=""

--- a/res/sample/configuration.toml
+++ b/res/sample/configuration.toml
@@ -78,6 +78,7 @@ LogLevel = "INFO"
       Mode = "bytimecount" # can be "bycount", "bytime" or "bytimecount"
       BatchThreshold = "30"
       TimeInterval = "60s"
+      MergeOnSend = "false"
     [Writable.Pipeline.Functions.SetResponseData]
       [Writable.Pipeline.Functions.SetResponseData.Parameters]
       ResponseContentType = "application/xml"


### PR DESCRIPTION
Set MergeOnSend = "true"
Set MergeOnSend = "false" in other profiles that use batch

closes #411

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  TBD

## Testing Instructions
Build and run App Template service to generate metrics
Build ASC with this branch
Configure ASC metrics-profile with HTTP to send to InfluxDB
Run ASC with metrics-profile with DEBUG logging
Verify HTTP Export reports status is 204 No Content in log file

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->