### PR TITLE
docs(snap): Remove usage instructions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ For docker, please refer to the [Dockerfile](Dockerfile) and [Docker Compose Bui
 
 For the snap, refer to the [snap](snap) directory.
 
-The details of the EdgeX release artifacts are available [here](https://docs.edgexfoundry.org/2.1/design/adr/devops/0010-Release-Artifacts).
-
 ## Versioning
 
 Please refer to the EdgeX Foundry [versioning policy](https://wiki.edgexfoundry.org/pages/viewpage.action?pageId=21823969) for information on how EdgeX services are released and how EdgeX services are compatible with one another.  Specifically, device services (and the associated SDK), application services (and the associated app functions SDK), and client tools (like the EdgeX CLI and UI) can have independent minor releases, but these services must be compatible with the latest major release of EdgeX.

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,212 +1,23 @@
-# EdgeX Foundry App Service Configurable Snap
-[![snap store badge](https://raw.githubusercontent.com/snapcore/snap-store-badges/master/EN/%5BEN%5D-snap-store-black-uneditable.png)](https://snapcraft.io/edgex-app-service-configurable)
+# EdgeX App Service Configurable Snap
+[![edgex-app-service-configurable](https://snapcraft.io/edgex-app-service-configurable/badge.svg)](https://snapcraft.io/edgex-app-service-configurable)
 
-This folder contains snap packaging for the EdgeX Foundry's App Service Configurable application service.
+This folder contains the snap packaging of the EdgeX App Service Configurable application service.
 
-The project maintains a rolling release of the snap on the `edge` channel that is rebuilt and published at least once daily.
+For usage instructions, please refer to [docs](https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#app-service-configurable).
 
-The snap currently supports both `amd64` and `arm64` platforms.
+## Build
+To build the snap from source, execute the following command from the top-level directory of this repo:
+```
+snapcraft
+```
 
-## Installation
+Please refer to [snapcraft documentation](https://snapcraft.io/docs) for details.
 
-### Installing snapd
-The snap can be installed on any system that supports snaps. You can see how to install 
-snaps on your system [here](https://snapcraft.io/docs/installing-snapd/6735).
+### Obtain a secret store token
+When this and the edgexfoundry snap are installed from the store, the Secret Store token is provided automatically using the auto-connected `edgex-secretstore-token` [content interface](https://snapcraft.io/docs/content-interface).
 
-However for full security confinement, the snap should be installed on an 
-Ubuntu 18.04 LTS or later (Desktop or Server), or a system running Ubuntu Core 18 or later.
-
-### Installing EdgeX App Service Configurable as a snap
-The snap is published in the snap store as [edgex-app-service-configurable](https://snapcraft.io/edgex-app-service-configurable).
-See the current revisions available for your machine's architecture:
+If the snap is build locally, the auto connection will not happen. This can be verified by running the `snap connections <snap>` command. To manually connect and obtain the token:
 
 ```bash
-snap info edgex-app-service-configurable
+sudo snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token 
 ```
-
-The latest stable version of the snap can be installed using:
-
-```bash
-sudo snap install edgex-app-service-configurable
-```
-
-A specific version of the snap can be installed by setting the channel, 
-for instance for 2.1 (Jakarta):
-
-```bash
-sudo snap install edgex-app-service-configurable --channel=2.1
-```
-
-The latest development version of the snap can be installed using:
-
-```bash
-sudo snap install edgex-app-service-configurable --edge
-```
-
-**Note** - the snap has only been tested on Ubuntu Core, Desktop, and Server.
-
-## Using the EdgeX App Service Configurable snap
-
-The App Service Configurable application service allows a variety of use cases to be met by simply providing configuration. 
-
-This service is disabled when first installed, 
-as a profile must first be selected before the service is started. 
-See [profile](#profiles) section below.
-
-For more information about this service, 
-please refer to the [EdgeX App Service Configurable README](../README.md).
-
-### Profiles
-There are a number of sub-directories in the snap's configuration directory, 
-these sub-directories are referred to as profiles. 
-Before you can start the service, you must select one of them, 
-using the `snap set` command (or via [snapd's REST API](https://snapcraft.io/docs/snapd-api). 
-For example, to use the mqtt-export profile you would run:
-
-```bash
-sudo snap set edgex-app-service-configurable profile=mqtt-export
-```
-
-In addition to instructing the service to read a different configuration file, 
-the profile will also be used to name the service when it registers itself to the system.
-For details on currently available profiles, please see [here](../res).
-
-The `configuration.toml` files are found in the snap’s writable area: 
-```
-/var/snap/edgex-app-service-configurable/current/config/res/
-```
-
-The service can then be started as follows. The `--enable` option
-ensures that as well as starting the service now, it will be automatically started on boot:
-```bash
-sudo snap start --enable edgex-app-service-configurable
-```
-**Note** - Should the environment variables be modified after the service has started, 
-the service must be restarted.
-
-### Configuration Overrides
-While it's possible to manually edit the profile-specific `configuration.toml` files (found in `$SNAP_DATA/config/res/<profile>`)
-prior to enabling the service, quite often only minor changes to existing profiles are required. These changes can be accomplished via
-support for [EdgeX environment variable configuration overrides](#service-environment-configuration-overrides) via the snap's configure hook. 
-If the service has already been started,
-setting one of these overrides currently requires the service to be restarted via the command-line or snapd's REST API. 
-If the overrides are provided via the snap configuration defaults capability of a [gadget snap](https://snapcraft.io/docs/gadget-snap), 
-the overrides will be picked up when the services are first started.
-
-The following syntax is used to specify service-specific configuration overrides:
-
-```
-env.<stanza>.<config option>
-```
-
-For instance, to setup an override of the service's port:
-
-```bash
-sudo snap set env.service.port=2112
-```
-
-And restart the service:
-
-```bash
-sudo snap restart edgex-app-service-configurable
-```
-
-**Note** - at this time changes to configuration values in the [Writable] section are not supported.
-
-For details on the mapping of configuration options to Config options, 
-please refer to [Service Environment Configuration Overrides](#service-environment-configuration-overrides) section below.
-
-### Using a content interface to set app configuration
-
-The `app-config` content interface allows another snap to seed this application snap 
-with configuration files under the `$SNAP_DATA/config` directory.
-
-Note that the `app-config` content interface does NOT support seeding of the Secret Store Token
-because that file is expected at a different path.
-
-Please refer to [edgex-config-provider](https://github.com/canonical/edgex-config-provider), for an example and further instructions.
-
-### Autostart
-By default, the edgex-app-service-configurable disables its service on install, 
-as the expectation is that the default profile configuration files will be customized, 
-and thus this behavior allows the profile `configuration.toml` files in [`$SNAP_DATA`](https://snapcraft.io/docs/environment-variables) to be modified before the service is first started.
-
-This behavior can be overridden by setting the `autostart` configuration setting to `true`. 
-This is useful when configuration and/or device profiles are being provided via configuration or gadget snap content interface.
-
-**Note** - this option is typically set from a gadget snap.
-
-
-## Service Environment Configuration Overrides
-Application services implement a service dependency check on startup which ensures that all of the runtime dependencies of a particular service are met before the service transitions to an active state.
-
-Snapd doesn't support orchestration between services in different snaps. 
-It is therefore possible on a reboot for an application service to come up faster than all of the required services running in the main edgexfoundry snap. 
-If this happens, the application service may repeatedly fail startup, 
-and if it exceeds the systemd default limits, 
-then it might be left in a failed state. 
-This situation might be more likely on constrained hardware (e.g. RPi).
-
-This snap, therefore, implements a basic retry loop with a maximum `startup-duration` and `startup-interval`. 
-If the dependent services are not available, 
-the service sleeps for the defined interval and then tries again up to a maximum duration. 
-EdgeX services wait for dependencies (e.g. core-data) to become available and will exit after reaching the maximum duration if the dependencies aren't met. 
-    
-This environment variable sets the total duration in seconds allowed for the services to complete the bootstrap start-up. 
-Default is 60 seconds. Change the maximum duration:
-
-```bash
-sudo snap set edgex-app-service-configurable startup-duration=120
-```
-
-This environment variable sets the retry interval in seconds for the services retrying a failed action during the bootstrap start-up.
-Default is 1 second. Change the interval between retries:
-
-```bash
-sudo snap set edgex-app-service-configurable startup-interval=3
-```
-
-**Note** - all of the configuration options below must be specified with the prefix: `env.`
-
-```
-[Service]
-service.health-check-interval   // Service.HealthCheckInterval
-service.host                    // Service.Host
-service.server-bind-addr        // Service.ServerBindAddr
-service.port                    // Service.Port
-service.max-result-count        // Service.MaxResultCount
-service.max-request-size        // Service.MaxRequestSize
-service.startup-msg             // Service.StartupMsg
-service.request-timeout         // Service.RequestTimeout
-
-[SecretStore]
-secret-store.secrets-file               // SecretStore.SecretsFile
-secret-store.disable-scrub-secrets-file // SecretStore.DisableScrubSecretsFile
-
-[Clients.core-command]
-clients.core-command.port       // Clients.core-command.Port
-
-[Clients.core-data]
-clients.core-data.port          // Clients.core-data.Port
-
-[Clients.core-metadata]
-clients.core-metadata.port      // Clients.core-metadata.Port
-
-[Clients.support-notifications]
-clients.support-notifications.port  // Clients.support-notifications.Port
-
-[Triger]
-[Trigger.EdgexMessageBus]
-trigger.edgex-message-bus.type                             // Trigger.EdgexMessageBus.Type
-
-[Trigger.EdgexMessageBus.SubscribeHost]
-trigger.edgex-message-bus.subscribe-host.port              // Trigger.EdgexMessageBus.SubscribeHost.Port
-trigger.edgex-message-bus.subscribe-host.protocol          // Trigger.EdgexMessageBus.SubscribeHost.Protocol
-trigger.edgex-message-bus.subscribe-host.subscribe-topics  // Trigger.EdgexMessageBus.SubscribeHost.SubscribeTopics
-
-[Trigger.EdgexMessageBus.PublishHost]
-trigger.edgex-message-bus.publish-host.port                // Trigger.EdgexMessageBus.PublishHost.Port
-trigger.edgex-message-bus.publish-host.protocol            // Trigger.EdgexMessageBus.PublishHost.Protocol
-trigger.edgex-message-bus.publish-host.publish-topic       // Trigger.EdgexMessageBus.PublishHost.PublishTopic
-```
-

--- a/snap/README.md
+++ b/snap/README.md
@@ -5,7 +5,7 @@ This directory contains the snap packaging of the EdgeX App Service Configurable
 
 The snap is built automatically and published on the Snap Store as [edgex-app-service-configurable].
 
-For usage instructions, please refer to [docs](https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#app-service-configurable).
+For usage instructions, please refer to [docs].
 
 ## Build from source
 Execute the following command from the top-level directory of this repo:
@@ -13,24 +13,26 @@ Execute the following command from the top-level directory of this repo:
 snapcraft
 ```
 
-This will create binary snap package with a `.snap` extension which can be installed locally by setting the `--dangerous` flag:
+This will create a snap package file with `.snap` extension. It can be installed locally by setting the `--dangerous` flag:
 ```bash
-sudo snap install --dangerous <snap>.snap
+sudo snap install --dangerous <snap-file>
 ```
 
-Please refer to [snapcraft documentation](https://snapcraft.io/docs) for more details.
+Please refer to [snapcraft overview](https://snapcraft.io/docs/snapcraft-overview) for more details.
 
-### Obtain a secret store token
-When this and the [edgexfoundry] snap are installed from the store, the Secret Store token is provided automatically using the auto-connected `edgex-secretstore-token` [content interface](https://snapcraft.io/docs/content-interface).
+### Obtain a Secret Store token
+The `edgex-secretstore-token` snap slot makes it possible to automatically receive a token from a locally installed platform snap.
 
-If the snap is build locally, the auto connection will not happen. This can be verified by running the `snap connections edgex-app-service-configurable` command.
+If the snap is built and installed locally, the interface will not auto-connect. You can check the status of the connections by running the `snap connections edgex-app-service-configurable` command.
 
-To manually connect and obtain the token:
+To manually connect and obtain a token:
 ```bash
 sudo snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token
 ```
 
-To better understand the snap connections, read the [interface management](https://snapcraft.io/docs/interface-management) documentation.
+Please refer to [secret-store-token] docs for details.
 
-[edgexfounndry]: https://snapcraft.io/edgexfoundry
+
 [edgex-app-service-configurable]: https://snapcraft.io/edgex-app-service-configurable
+[docs]: https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#app-service-configurable
+[secret-store-token]: https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#secret-store-token

--- a/snap/README.md
+++ b/snap/README.md
@@ -5,7 +5,7 @@ This directory contains the snap packaging of the EdgeX App Service Configurable
 
 The snap is built automatically and published on the Snap Store as [edgex-app-service-configurable].
 
-For usage instructions, please refer to [docs].
+For usage instructions, please refer to App Service Configurable section in [Getting Started using Snaps][docs].
 
 ## Build from source
 Execute the following command from the top-level directory of this repo:
@@ -18,7 +18,7 @@ This will create a snap package file with `.snap` extension. It can be installed
 sudo snap install --dangerous <snap-file>
 ```
 
-Please refer to [snapcraft overview](https://snapcraft.io/docs/snapcraft-overview) for more details.
+The [snapcraft overview](https://snapcraft.io/docs/snapcraft-overview) provides additional details.
 
 ### Obtain a Secret Store token
 The `edgex-secretstore-token` snap slot makes it possible to automatically receive a token from a locally installed platform snap.
@@ -30,7 +30,7 @@ To manually connect and obtain a token:
 sudo snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token
 ```
 
-Please refer to [secret-store-token] docs for details.
+Please refer [here][secret-store-token] for further information.
 
 
 [edgex-app-service-configurable]: https://snapcraft.io/edgex-app-service-configurable

--- a/snap/README.md
+++ b/snap/README.md
@@ -13,15 +13,24 @@ Execute the following command from the top-level directory of this repo:
 snapcraft
 ```
 
-Please refer to [snapcraft documentation](https://snapcraft.io/docs) for details.
-
-### Obtain a secret store token
-When this and the edgexfoundry snap are installed from the store, the Secret Store token is provided automatically using the auto-connected `edgex-secretstore-token` [content interface](https://snapcraft.io/docs/content-interface).
-
-If the snap is build locally, the auto connection will not happen. This can be verified by running the `snap connections <snap>` command. To manually connect and obtain the token:
-
+This will create binary snap package with a `.snap` extension which can be installed locally by setting the `--dangerous` flag:
 ```bash
-sudo snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token 
+sudo snap install --dangerous <snap>.snap
 ```
 
+Please refer to [snapcraft documentation](https://snapcraft.io/docs) for more details.
+
+### Obtain a secret store token
+When this and the [edgexfoundry] snap are installed from the store, the Secret Store token is provided automatically using the auto-connected `edgex-secretstore-token` [content interface](https://snapcraft.io/docs/content-interface).
+
+If the snap is build locally, the auto connection will not happen. This can be verified by running the `snap connections edgex-app-service-configurable` command.
+
+To manually connect and obtain the token:
+```bash
+sudo snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token
+```
+
+To better understand the snap connections, read the [interface management](https://snapcraft.io/docs/interface-management) documentation.
+
+[edgexfounndry]: https://snapcraft.io/edgexfoundry
 [edgex-app-service-configurable]: https://snapcraft.io/edgex-app-service-configurable

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,12 +1,14 @@
 # EdgeX App Service Configurable Snap
-[![edgex-app-service-configurable](https://snapcraft.io/edgex-app-service-configurable/badge.svg)](https://snapcraft.io/edgex-app-service-configurable)
+[![edgex-app-service-configurable](https://snapcraft.io/edgex-app-service-configurable/badge.svg)][edgex-app-service-configurable]
 
-This folder contains the snap packaging of the EdgeX App Service Configurable application service.
+This directory contains the snap packaging of the EdgeX App Service Configurable application service.
+
+The snap is built automatically and published on the Snap Store as [edgex-app-service-configurable].
 
 For usage instructions, please refer to [docs](https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#app-service-configurable).
 
-## Build
-To build the snap from source, execute the following command from the top-level directory of this repo:
+## Build from source
+Execute the following command from the top-level directory of this repo:
 ```
 snapcraft
 ```
@@ -21,3 +23,5 @@ If the snap is build locally, the auto connection will not happen. This can be v
 ```bash
 sudo snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token 
 ```
+
+[edgex-app-service-configurable]: https://snapcraft.io/edgex-app-service-configurable


### PR DESCRIPTION
Usage instructions are being moved to docs; see https://github.com/edgexfoundry/edgex-docs/pull/751.
The snap/README has been updated to include development docs only.

Depends on:
- https://github.com/edgexfoundry/edgex-docs/pull/751

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->