### PR TITLE
refactor: Remove obsolete commented out Host settings

### DIFF
--- a/res/external-mqtt-trigger/configuration.yaml
+++ b/res/external-mqtt-trigger/configuration.yaml
@@ -11,7 +11,7 @@ Writable:
       MQTTExport:
         Parameters:
           BrokerAddress: "tcp://localhost:1883" # Hive Public Test Broker
-          # Topic can have place holders in the form "{key-name}" that are replaced with matching Context values. Error occurs if no value match place holder(s).
+          # Topic can have placeholders in the form "{key-name}" that are replaced with matching Context values. Error occurs if no value match place holder(s).
           Topic: "edgex-export"
           SecretName: "mqtt"
           ClientId: "external-mqtt-export"
@@ -33,18 +33,8 @@ Service:
   Port: 59706
   StartupMsg: "app-external-mqtt-trigger has Started"
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-# Clients:
-#   core-metadata:
-#       Host: "localhost"
-# Registry:
-#   Host: "localhost"
-# Database:
-#   Host: "localhost" 
-
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
-  Disabled: true  # Set to false when collecting metrics 
+  Disabled: true  # Set to false when collecting metrics
 
 Trigger:
   Type: "external-mqtt"

--- a/res/functional-tests/configuration.yaml
+++ b/res/functional-tests/configuration.yaml
@@ -74,18 +74,8 @@ Service:
   Port: 59705
   StartupMsg: "app-functional-tests Service Started"
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-# Clients:
-#   core-metadata:
-#       Host: "localhost"
-# Registry:
-#   Host: "localhost"
-# Database:
-#   Host: "localhost" 
-
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
-  Disabled: true  # Set to false when collecting metrics  
+  Disabled: true  # Set to false when collecting metrics
 
 Trigger:
   Type: "http"

--- a/res/http-export/configuration.yaml
+++ b/res/http-export/configuration.yaml
@@ -85,17 +85,7 @@ Service:
   Port: 59704
   StartupMsg: "app-http-export has Started"
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-# Clients:
-#   core-metadata:
-#       Host: "localhost"
-# Registry:
-#   Host: "localhost"
-# Database:
-#   Host: "localhost" 
-
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: "app-http-export"
 

--- a/res/metrics-influxdb/configuration.yaml
+++ b/res/metrics-influxdb/configuration.yaml
@@ -40,17 +40,7 @@ Service:
   Port: 59707
   StartupMsg: "app-metrics-influxdb has Started"
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-# Clients:
-#   core-metadata:
-#       Host: "localhost"
-# Registry:
-#   Host: "localhost"
-# Database:
-#   Host: "localhost" 
-
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: "app-metrics-influxdb"
 

--- a/res/mqtt-export/configuration.yaml
+++ b/res/mqtt-export/configuration.yaml
@@ -77,17 +77,7 @@ Service:
   Port: 59703
   StartupMsg: "app-mqtt-export has Started"
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-# Clients:
-#   core-metadata:
-#       Host: "localhost"
-# Registry:
-#   Host: "localhost"
-# Database:
-#   Host: "localhost" 
-
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: "app-mqtt-export"
 

--- a/res/rules-engine/configuration.yaml
+++ b/res/rules-engine/configuration.yaml
@@ -30,17 +30,7 @@ Service:
   Port: 59701
   StartupMsg: "app-rules-engine has Started"
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-# Clients:
-#   core-metadata:
-#       Host: "localhost"
-# Registry:
-#   Host: "localhost"
-# Database:
-#   Host: "localhost" 
-
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: "app-rules-engine"
 

--- a/res/sample/configuration.yaml
+++ b/res/sample/configuration.yaml
@@ -144,17 +144,7 @@ Service:
   Port: 59700
   StartupMsg: "app-sample has Started"
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-#Clients:
-#  core-metadata: # Used for version check on start-up comes from Common Config
-#      Host: "localhost"
-#Registry:
-#  Host: "localhost"
-#Database:
-#  Host: "localhost"
-
 MessageBus:
-#  Host: localhost # uncomment when running from command-line in hybrid mode
   Disabled: false  # Set to true if not using edgex-messagebus Trigger below and don't want Metrics
   Optional:
     ClientId: "app-sample"


### PR DESCRIPTION
We now have the -d/--dev command line flag to set the Host stetting automatically

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **N/A**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->