### PR TITLE
feat: Add new build-noziti and docker-noziti targets into Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ make docker-nats - Builds local docker image with NATS MessageBus support
 The locally built Docker image can then be used in place of the published Docker image in your compose file.
 See [Compose Builder](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder#gen) `nat-bus` option to generate compose file for NATS and local dev images.
 
+## Build without OpenZiti zerotrust
+Currently, the OpenZiti zerotrust capability is opt-out at build time. This means that the published Docker images include the OpenZiti zerotrust capability.
+
+The following make commands will build the local binaries or local Docker images without OpenZiti zerotrust capability.
+
+```makefile
+make build-noziti
+make docker-noziti
+```
+
 ## Packaging
 
 This component is packaged as docker image.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/app-service-configurable
 
 go 1.23
 
-require github.com/edgexfoundry/app-functions-sdk-go/v4 v4.0.0-dev.10
+require github.com/edgexfoundry/app-functions-sdk-go/v4 v4.0.0-dev.11
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -11,7 +11,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/diegoholiveira/jsonlogic/v3 v3.5.3 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.5.0 // indirect
-	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.8 // indirect
+	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.9 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.4 // indirect
 	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.5 // indirect
 	github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,10 +72,10 @@ github.com/diegoholiveira/jsonlogic/v3 v3.5.3 h1:CPyZQ3fOgiIDZ1yWzPGUpyht5tYTOnR
 github.com/diegoholiveira/jsonlogic/v3 v3.5.3/go.mod h1:3nnfWovrlZq2rTpucrJ2KMIS8TMf6IoFneofmeqk/qk=
 github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
 github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
-github.com/edgexfoundry/app-functions-sdk-go/v4 v4.0.0-dev.10 h1:pRPHsAvkymAJ1QW27Mj+dZmFItzrH8z3Q5SR4jmdx0Q=
-github.com/edgexfoundry/app-functions-sdk-go/v4 v4.0.0-dev.10/go.mod h1:/51KC+wM/9ncn9ie3cljTrFdME8630/64Aj9c7YR44I=
-github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.8 h1:uFy9gOVPCLIyYcHcyP8dWBiGPKBvLS+PfaHK9ab/Z9s=
-github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.8/go.mod h1:IvrZ7zaD/0kvN+aAtqdudAPGOa4DprO4SDU3JQhVBUY=
+github.com/edgexfoundry/app-functions-sdk-go/v4 v4.0.0-dev.11 h1:wCg6uYosbnEhskIkm66rFH6uR0xNfQiZluANURiH1Fo=
+github.com/edgexfoundry/app-functions-sdk-go/v4 v4.0.0-dev.11/go.mod h1:0mN6ND+0EH1ERN0UEuWlQy1khhqmrp0MktWA1OoBt44=
+github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.9 h1:GM0LR1f+fAy79G9GpKvKmqX+owrbaT3fhWT6MNBmEbs=
+github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.9/go.mod h1:IvrZ7zaD/0kvN+aAtqdudAPGOa4DprO4SDU3JQhVBUY=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.4 h1:Bw8Bxoc2LjAfkgWvAQtbeqnAaGPmKiCoAHlHGalhnv4=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.4/go.mod h1:Jc8kjQTAUYzuHbQzRuVzfPZy3QfJGMQ0rGHOhRit7to=
 github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.5 h1:PHcgm730GAjl8hR5y25OE+YEe6urZhYIcIYGY7TeCWM=

--- a/makefile
+++ b/makefile
@@ -38,6 +38,9 @@ build:
 build-nats:
 	make -e ADD_BUILD_TAGS=include_nats_messaging build
 
+build-noziti:
+	make -e ADD_BUILD_TAGS=no_openziti build
+
 tidy:
 	go mod tidy
 
@@ -55,6 +58,9 @@ docker:
 
 docker-nats:
 	make -C . -e ADD_BUILD_TAGS=include_nats_messaging docker
+
+docker-noziti:
+	make -e ADD_BUILD_TAGS=no_openziti docker
 
 lint:
 	@which golangci-lint >/dev/null || echo "WARNING: go linter not installed. To install, run make install-lint"


### PR DESCRIPTION
related to https://github.com/edgexfoundry/go-mod-bootstrap/pull/795

To allow to build services without openziti, add new targte build-noziti and docker-noziti into Makefile. Also revise README.md to include such information.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-service-configurable/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->